### PR TITLE
Add proper support for SDL2's new versioning scheme

### DIFF
--- a/doc/news.rst
+++ b/doc/news.rst
@@ -22,6 +22,7 @@ New Features:
 * Added an informative warning for users using pysdl2-dll with PySDL2 on an
   Apple Silicon Mac.
 
+
 Fixed Bugs:
 
 * Fixed a bug in :func:`~sdl2.rw_from_object` where calling 
@@ -46,6 +47,8 @@ Fixed Bugs:
   the SDL2 headers.
 * Fixed export of ``SDL_TIMER_RESOLUTION`` hint (was previously not accessable
   through the ``sdl2`` namespace).
+* Updated ``sdl2.dll.version`` to better handle SDL2's new versioning format
+  and fixed unit tests accordingly (issue #228).
 
 
 0.9.11

--- a/sdl2/dll.py
+++ b/sdl2/dll.py
@@ -63,12 +63,23 @@ class SDL_version(Structure):
     ]
 
 def _version_str_to_int(s):
+    # Convert an SDL version string to an integer (e.g. "2.0.18" to 2018)
     v = [int(n) for n in s.split('.')]
-    return v[0] * 1000 + v[1] * 100 + v[2]
+    if v[1] > 0:
+        # For SDL2 >= 2.23.0 (new version scheme): 2.23.0 -> 2230
+        return v[0] * 1000 + v[1] * 10 + v[2]
+    else:
+        # For SDL2 <= 2.0.22 (old version scheme): 2.0.22 -> 2022
+        return v[0] * 1000 + v[1] * 100 + v[2]
 
 def _version_int_to_str(i):
     v = str(i)
-    v = [v[0], v[1], str(int(v[2:4]))]
+    if int(v[1]) > 0:
+        # For SDL2 >= 2.23.0 (new version scheme): 2230 -> 2.23.0
+        v = [v[0], str(int(v[1:3])), v[3]]
+    else:
+        # For SDL2 <= 2.0.22 (old version scheme): 2022 -> 2.0.22
+        v = [v[0], v[1], str(int(v[2:4]))]
     return ".".join(v)
 
 def _so_version_num(libname):
@@ -322,7 +333,7 @@ class DLL(object):
     @property
     def version(self):
         """int: The version of the loaded library in the form of a 4-digit
-        integer (e.g. '2008' for SDL 2.0.8, '2010' for SDL 2.0.10).
+        integer (e.g. '2008' for SDL 2.0.8, '2231' for SDL 2.23.1).
         """
         return self._version
 

--- a/sdl2/test/sdlimage_test.py
+++ b/sdl2/test/sdlimage_test.py
@@ -90,7 +90,7 @@ def test_IMG_Linked_Version():
     v = sdlimage.IMG_Linked_Version()
     assert isinstance(v.contents, version.SDL_version)
     assert v.contents.major == 2
-    assert v.contents.minor == 0
+    assert v.contents.minor >= 0
     assert v.contents.patch >= 1
 
 def test_IMG_Init():

--- a/sdl2/test/sdlmixer_test.py
+++ b/sdl2/test/sdlmixer_test.py
@@ -19,7 +19,7 @@ def test_Mix_Linked_Version():
     v = sdlmixer.Mix_Linked_Version()
     assert isinstance(v.contents, version.SDL_version)
     assert v.contents.major == 2
-    assert v.contents.minor == 0
+    assert v.contents.minor >= 0
     assert v.contents.patch >= 0
 
 @pytest.mark.skipif(sdlmixer.dll.version < 2004, reason="Broken in official binaries")

--- a/sdl2/test/sdlttf_test.py
+++ b/sdl2/test/sdlttf_test.py
@@ -66,7 +66,7 @@ def test_TTF_Linked_Version(with_sdl_ttf):
     v = sdlttf.TTF_Linked_Version()
     assert isinstance(v.contents, version.SDL_version)
     assert v.contents.major == 2
-    assert v.contents.minor == 0
+    assert v.contents.minor >= 0
     assert v.contents.patch >= 12
 
 @pytest.mark.skipif(sdlttf.dll.version < 2018, reason="not available")

--- a/sdl2/test/version_test.py
+++ b/sdl2/test/version_test.py
@@ -16,7 +16,7 @@ def test_SDL_GetVersion():
     sdl2.SDL_GetVersion(ctypes.byref(v))
     assert type(v) == sdl2.SDL_version
     assert v.major == 2
-    assert v.minor == 0
+    assert v.minor >= 0
     assert v.patch >= 5
 
 def test_SDL_VERSIONNUM():


### PR DESCRIPTION
<!--Thanks for contributing to PySDL2!-->

# PR Description

Closes #228.

This PR fixes the unit tests that expect the SDL2 minor version to always be 0, and also updates the internal version string-to-int and int-to-string functions to correctly parse the new versions. Note that the updated code assumes that the patch level for future SDL2 releases will always be a single digit, which I think seems safe.


# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/marcusva/py-sdl2/blob/master/doc/news.rst
