### PR TITLE
Handle SDL 2.23+ new versioning scheme

### DIFF
--- a/sdl2/test/sdlimage_test.py
+++ b/sdl2/test/sdlimage_test.py
@@ -54,7 +54,7 @@ if bad_webp:
     formats.remove("webp")
 
 # JPG saving requires SDL2_image >= 2.0.2 and isn't in official mac binaries
-no_jpeg_save = sdlimage.dll.version < 2002 or ismacos
+no_jpeg_save = sdlimage.dll.version_tuple < (2, 0, 2) or ismacos
 
 @pytest.fixture(scope="module")
 def with_sdl_image(with_sdl):
@@ -94,6 +94,7 @@ def test_IMG_Linked_Version():
     assert v.contents.patch >= 0
     t = (v.contents.major, v.contents.minor, v.contents.patch)
     assert t >= (2, 0, 1)
+    assert t == sdlimage.dll.version_tuple
 
 def test_IMG_Init():
     SDL_Init(0)

--- a/sdl2/test/sdlimage_test.py
+++ b/sdl2/test/sdlimage_test.py
@@ -91,7 +91,9 @@ def test_IMG_Linked_Version():
     assert isinstance(v.contents, version.SDL_version)
     assert v.contents.major == 2
     assert v.contents.minor >= 0
-    assert v.contents.patch >= 1
+    assert v.contents.patch >= 0
+    t = (v.contents.major, v.contents.minor, v.contents.patch)
+    assert t >= (2, 0, 1)
 
 def test_IMG_Init():
     SDL_Init(0)

--- a/sdl2/test/sdlmixer_test.py
+++ b/sdl2/test/sdlmixer_test.py
@@ -21,6 +21,8 @@ def test_Mix_Linked_Version():
     assert v.contents.major == 2
     assert v.contents.minor >= 0
     assert v.contents.patch >= 0
+    t = (v.contents.major, v.contents.minor, v.contents.patch)
+    assert t >= (2, 0, 0)
 
 @pytest.mark.skipif(sdlmixer.dll.version < 2004, reason="Broken in official binaries")
 def test_Mix_Init():

--- a/sdl2/test/sdlmixer_test.py
+++ b/sdl2/test/sdlmixer_test.py
@@ -23,8 +23,9 @@ def test_Mix_Linked_Version():
     assert v.contents.patch >= 0
     t = (v.contents.major, v.contents.minor, v.contents.patch)
     assert t >= (2, 0, 0)
+    assert t == sdlmixer.dll.version_tuple
 
-@pytest.mark.skipif(sdlmixer.dll.version < 2004, reason="Broken in official binaries")
+@pytest.mark.skipif(sdlmixer.dll.version_tuple < (2, 0, 4), reason="Broken in official binaries")
 def test_Mix_Init():
     SDL_Init(sdl2.SDL_INIT_AUDIO)
     supported = []

--- a/sdl2/test/sdlttf_test.py
+++ b/sdl2/test/sdlttf_test.py
@@ -67,7 +67,9 @@ def test_TTF_Linked_Version(with_sdl_ttf):
     assert isinstance(v.contents, version.SDL_version)
     assert v.contents.major == 2
     assert v.contents.minor >= 0
-    assert v.contents.patch >= 12
+    assert v.contents.patch >= 0
+    t = (v.contents.major, v.contents.minor, v.contents.patch)
+    assert t >= (2, 0, 12)
 
 @pytest.mark.skipif(sdlttf.dll.version < 2018, reason="not available")
 def test_TTF_GetFreeTypeVersion(with_sdl_ttf):

--- a/sdl2/test/sdlttf_test.py
+++ b/sdl2/test/sdlttf_test.py
@@ -70,6 +70,7 @@ def test_TTF_Linked_Version(with_sdl_ttf):
     assert v.contents.patch >= 0
     t = (v.contents.major, v.contents.minor, v.contents.patch)
     assert t >= (2, 0, 12)
+    assert t == sdlttf.dll.version_tuple
 
 @pytest.mark.skipif(sdlttf.dll.version < 2018, reason="not available")
 def test_TTF_GetFreeTypeVersion(with_sdl_ttf):
@@ -240,7 +241,7 @@ def test_TTF_GetSetFontHinting(with_font):
         sdlttf.TTF_HINTING_NORMAL, sdlttf.TTF_HINTING_LIGHT,
         sdlttf.TTF_HINTING_MONO, sdlttf.TTF_HINTING_NONE
     ]
-    if sdlttf.dll.version >= 2018:
+    if sdlttf.dll.version_tuple >= (2, 0, 18):
         hints.append(sdlttf.TTF_HINTING_LIGHT_SUBPIXEL)
     assert sdlttf.TTF_GetFontHinting(font) == sdlttf.TTF_HINTING_NORMAL
     for hint in hints:

--- a/sdl2/test/version_test.py
+++ b/sdl2/test/version_test.py
@@ -17,7 +17,8 @@ def test_SDL_GetVersion():
     assert type(v) == sdl2.SDL_version
     assert v.major == 2
     assert v.minor >= 0
-    assert v.patch >= 5
+    assert v.patch >= 0
+    assert (v.major, v.minor, v.patch) >= (2, 0, 5)
 
 def test_SDL_VERSIONNUM():
     assert sdl2.SDL_VERSIONNUM(1, 2, 3) == 1203

--- a/sdl2/test/version_test.py
+++ b/sdl2/test/version_test.py
@@ -5,6 +5,16 @@ import sdl2
 from sdl2 import dll, __version__, version_info
 
 
+def test__version_tuple():
+    # Note that this is not public API.
+    assert dll._version_tuple_to_int((2, 0, 18)) == 2018
+    assert dll._version_tuple_to_int((2, 24, 1)) == 2241
+    # Micro version stops at 9 in this encoding
+    assert dll._version_tuple_to_int((2, 24, 15)) == 2249
+    assert dll._version_tuple_to_int((2, 99, 9)) == 2999
+    # Minor version stops at 99 in this encoding
+    assert dll._version_tuple_to_int((2, 103, 6)) == 2999
+
 def test_SDL_version():
     v = sdl2.SDL_version(0, 0, 0)
     assert v.major == 0
@@ -19,6 +29,7 @@ def test_SDL_GetVersion():
     assert v.minor >= 0
     assert v.patch >= 0
     assert (v.major, v.minor, v.patch) >= (2, 0, 5)
+    assert (v.major, v.minor, v.patch) == dll.version_tuple
 
 def test_SDL_VERSIONNUM():
     assert sdl2.SDL_VERSIONNUM(1, 2, 3) == 1203
@@ -42,13 +53,13 @@ def test_SDL_GetRevision():
     rev = sdl2.SDL_GetRevision()
     # If revision not empty string (e.g. Conda), test the prefix
     if len(rev):
-        if dll.version >= 2016:
+        if dll.version_tuple >= (2, 0, 16):
             assert rev[0:4] == b"http"
         else:
             assert rev[0:3] == b"hg-"
 
 def test_SDL_GetRevisionNumber():
-    if sys.platform in ("win32",) or dll.version >= 2016:
+    if sys.platform in ("win32",) or dll.version_tuple >= (2, 0, 16):
         # HG tip on Win32 does not set any revision number
         assert sdl2.SDL_GetRevisionNumber() >= 0
     else:

--- a/sdl2/test/version_test.py
+++ b/sdl2/test/version_test.py
@@ -25,6 +25,12 @@ def test_SDL_VERSIONNUM():
     assert sdl2.SDL_VERSIONNUM(2, 0, 0) == 2000
     assert sdl2.SDL_VERSIONNUM(17, 42, 3) == 21203
 
+    # This is a bit weird now that SDL uses the minor version more often,
+    # but does sort in the correct order against all versions of SDL 2.
+    assert sdl2.SDL_VERSIONNUM(2, 23, 0) == 4300
+    # This is the highest possible SDL 2 version
+    assert sdl2.SDL_VERSIONNUM(2, 255, 99) == 27599
+
 def test_SDL_VERSION_ATLEAST():
     assert sdl2.SDL_VERSION_ATLEAST(1, 2, 3)
     assert sdl2.SDL_VERSION_ATLEAST(2, 0, 0)


### PR DESCRIPTION
# PR Description

Continuation from #229. Fixes #228 (really this time).

* test: Add more realistic tests of SDL_VERSIONNUM
    
    The minor version overflows into the thousands digit in 2.23.0 and up.
    Because the major version is fixed at 2 until SDL 3 (which will be a
    separate library, like the difference between SDL 1.2 and 2), the
    numbers from here can still be used as a sort order, but are now a bit
    more confusing than they used to be.

* test: Avoid assertions that will break in upcoming versions
    
    Future SDL 2 versions are going to make more use of the minor version,
    so SDL 2.0.22, SDL_image 2.0.5, SDL_mixer 2.0.4 and SDL_ttf 2.0.18 will
    be followed by 2.24.0, 2.6.0, 2.6.0 and 2.20.0 respectively.
    
    This means assertions like version.patch >= 5 will no longer be true, so
    compare the entire version number as a tuple instead.
    
    Resolves: https://github.com/py-sdl/py-sdl2/issues/228

* dll: Represent version number as a tuple, similar to sys.version_info
    
    This avoids artificially limiting the range of possible version numbers
    that will sort correctly.
    
    For developer convenience, leave dll.version and dll.DLL.version
    working in terms of small integers, because comparisons with those are
    less verbose.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/marcusva/py-sdl2/blob/master/doc/news.rst
