### PR TITLE
power_test: Relax assertions about known information

### DIFF
--- a/sdl2/test/power_test.py
+++ b/sdl2/test/power_test.py
@@ -11,11 +11,17 @@ def test_SDL_GetPowerInfo():
         sdl2.SDL_POWERSTATE_CHARGING,
         sdl2.SDL_POWERSTATE_CHARGED
     ]
+    no_battery = [
+        sdl2.SDL_POWERSTATE_NO_BATTERY
+    ]
     remaining, pct = c_int(), c_int()
     state = sdl2.SDL_GetPowerInfo(byref(remaining), byref(pct))
     if state in has_battery:
         assert pct.value <= 100
         assert pct.value > 0
-    else:
+    elif state in no_battery:
         assert remaining.value == -1
         assert pct.value == -1
+    # else no assertion about remaining and pct:
+    # we can have state SDL_POWERSTATE_UNKNOWN and still know a percentage
+    # if a battery is present but is not being charged


### PR DESCRIPTION
If a Linux laptop has been configured to stop charging the battery at
a value below 100% (to increase battery longevity by preventing
over-charging), and is charged to the configured maximum, SDL reports
that as SDL_POWERSTATE_UNKNOWN but still reports a percentage.

---

I wouldn't have noticed this, except that my laptop happens to make the assertion fail most of the time :-)

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/marcusva/py-sdl2/blob/master/doc/news.rst
