### PR TITLE
Fix unit tests on big-endian systems

### DIFF
--- a/doc/news.rst
+++ b/doc/news.rst
@@ -49,6 +49,7 @@ Fixed Bugs:
   through the ``sdl2`` namespace).
 * Updated ``sdl2.dll.version`` to better handle SDL2's new versioning format
   and fixed unit tests accordingly (issue #228).
+* Fixed various unit tests on big-endian platforms (PR #232).
 
 
 0.9.11

--- a/sdl2/test/pixels_test.py
+++ b/sdl2/test/pixels_test.py
@@ -9,9 +9,6 @@ from sdl2.stdinc import Uint8, Uint16, Uint32
 
 RGBA32 = [0xFF000000, 0x00FF0000, 0x0000FF00, 0x000000FF]
 RGBX32 = [0xFF000000, 0x00FF0000, 0x0000FF00, 0]
-if sys.byteorder == "big":
-    RGBA32.reverse()
-    RGBX32.reverse()
 
 
 # Test custom macros

--- a/sdl2/test/pixels_test.py
+++ b/sdl2/test/pixels_test.py
@@ -7,8 +7,8 @@ from sdl2 import SDL_Init, SDL_Quit, SDL_INIT_EVERYTHING, SDL_TRUE
 from sdl2 import SDL_Color
 from sdl2.stdinc import Uint8, Uint16, Uint32
 
-RGBA32 = [0xFF000000, 0x00FF0000, 0x0000FF00, 0x000000FF]
-RGBX32 = [0xFF000000, 0x00FF0000, 0x0000FF00, 0]
+RGBA8888 = [0xFF000000, 0x00FF0000, 0x0000FF00, 0x000000FF]
+RGBX8888 = [0xFF000000, 0x00FF0000, 0x0000FF00, 0]
 
 
 # Test custom macros
@@ -140,8 +140,8 @@ def test_SDL_GetPixelFormatName():
 
 def test_SDL_MasksToPixelFormatEnum():
     formats = [
-        (sdl2.SDL_PIXELFORMAT_RGBA8888, [32] + RGBA32),
-        (sdl2.SDL_PIXELFORMAT_RGBX8888, [32] + RGBX32),
+        (sdl2.SDL_PIXELFORMAT_RGBA8888, [32] + RGBA8888),
+        (sdl2.SDL_PIXELFORMAT_RGBX8888, [32] + RGBX8888),
         (sdl2.SDL_PIXELFORMAT_INDEX1MSB, [1, 0, 0, 0, 0]),
     ]
     for fmt, expected in formats:
@@ -154,8 +154,8 @@ def test_SDL_MasksToPixelFormatEnum():
 
 def test_SDL_PixelFormatEnumToMasks():
     formats = [
-        (sdl2.SDL_PIXELFORMAT_RGBA8888, [32] + RGBA32),
-        (sdl2.SDL_PIXELFORMAT_RGBX8888, [32] + RGBX32),
+        (sdl2.SDL_PIXELFORMAT_RGBA8888, [32] + RGBA8888),
+        (sdl2.SDL_PIXELFORMAT_RGBX8888, [32] + RGBX8888),
         (sdl2.SDL_PIXELFORMAT_INDEX1LSB, [1, 0, 0, 0, 0]),
         (sdl2.SDL_PIXELFORMAT_INDEX1MSB, [1, 0, 0, 0, 0]),
         (sdl2.SDL_PIXELFORMAT_UNKNOWN, [0, 0, 0, 0, 0]),

--- a/sdl2/test/sdl2ext_draw_test.py
+++ b/sdl2/test/sdl2ext_draw_test.py
@@ -16,7 +16,7 @@ except:
 
 @pytest.fixture
 def testsurf(with_sdl):
-    sf = SDL_CreateRGBSurface(0, 10, 10, 32, 0, 0, 0, 0)
+    sf = _create_surface((10, 10), fmt="RGBA32")
     assert SDL_GetError() == b""
     yield sf
     SDL_FreeSurface(sf)

--- a/sdl2/test/sdl2ext_image_test.py
+++ b/sdl2/test/sdl2ext_image_test.py
@@ -47,6 +47,10 @@ if _HASSDLIMAGE:
 # during tests
 skip_color_check = ['gif', 'jpg', 'lbm', 'pbm', 'pgm', 'svg', 'webp']
 
+# Skip ICO and CUR tests on big-endian, since they don't seem to work yet
+if sys.byteorder == "big":
+    skip_color_check += ['ico', 'cur']
+
 # SDL 2.0.10 has a bug that messes up converting surfaces with transparency
 if sdl2.dll.version == 2010:
     skip_color_check.append('xpm')

--- a/sdl2/test/sdl2ext_pixelaccess_test.py
+++ b/sdl2/test/sdl2ext_pixelaccess_test.py
@@ -30,7 +30,7 @@ def imgsurf(with_sdl):
 
 @pytest.fixture
 def rgbasurf(imgsurf):
-    rgba = pixels.SDL_PIXELFORMAT_ABGR8888
+    rgba = pixels.SDL_PIXELFORMAT_RGBA32
     rgbasurf = surface.SDL_ConvertSurfaceFormat(imgsurf.contents, rgba, 0)
     yield rgbasurf
     surface.SDL_FreeSurface(rgbasurf)

--- a/sdl2/test/sdl2ext_surface_test.py
+++ b/sdl2/test/sdl2ext_surface_test.py
@@ -2,6 +2,7 @@ import pytest
 from sdl2.surface import SDL_CreateRGBSurface, SDL_FreeSurface
 from sdl2.rect import SDL_Rect
 from sdl2.ext.draw import prepare_color, fill
+from sdl2.ext.surface import _create_surface
 from sdl2 import ext as sdl2ext
 
 try:
@@ -14,7 +15,7 @@ except:
 @pytest.mark.skipif(not _HASNUMPY, reason="Numpy not available")
 def test_subsurface(with_sdl):
     # Initialize colour and surface/view
-    sf = SDL_CreateRGBSurface(0, 10, 10, 32, 0, 0, 0, 0)
+    sf = _create_surface((10, 10), fmt="RGBA32")
     WHITE = prepare_color((255, 255, 255), sf)
 
     # Test creation of subsurface from parent


### PR DESCRIPTION
<!--Thanks for contributing to PySDL2!-->

# PR Description

Closes #227. Tested and working on a Power Mac G5 with SDL2 2.0.22 and Void Linux PowerPC 64-bit, except for the renderer tests which segfault because of a GL/Mesa/nouveau configuration issue (`glxgears` segfaults immediately too, so not a SDL2/PySDL2 problem).

So far all the fixes have been to the unit tests themselves, which were typically failing because they weren't written properly with big-endian in mind. The only area I have hesitations about are the `pixels3d` and related Numpy access functions, since the orders of RGBA tuples are inverted from little-endian systems, meaning that any code making assumptions about the byte order in those arrays wouldn't be readily portable. Not sure if that's something that should be left to developers themselves or taken care of internally in PySDL2.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/marcusva/py-sdl2/blob/master/doc/news.rst
