### PR TITLE
Fix SDL_TICKS_PASSED (#234)

### DIFF
--- a/sdl2/test/timer_test.py
+++ b/sdl2/test/timer_test.py
@@ -71,3 +71,10 @@ def test_SDL_AddRemoveTimer(with_sdl):
     assert len(calls) == orig_calls
     # Wait a bit, so the last executing handlers can finish
     sdl2.SDL_Delay(10)
+
+def test_SDL_TICKS_PASSED(with_sdl):
+    for A in (0, 9999, 0xFFFF0000, 0xFFFFFFFF):
+        assert sdl2.SDL_TICKS_PASSED(A, A)
+        for delta in (1, 100, 1000000, 0x7FFFFFFF):
+            assert sdl2.SDL_TICKS_PASSED(A, (A - delta) & 0xFFFFFFFF)
+            assert not sdl2.SDL_TICKS_PASSED(A, (A + delta) & 0xFFFFFFFF)

--- a/sdl2/timer.py
+++ b/sdl2/timer.py
@@ -23,7 +23,7 @@ SDL_TimerCallback = CFUNCTYPE(Uint32, Uint32, c_void_p)
 # Macros & inline functions
 
 def SDL_TICKS_PASSED(A, B):
-    return (B - A) <= 0
+    return ((A - B) & 0xFFFFFFFF) <= 0x80000000
 
 
 # Raw ctypes function definitions


### PR DESCRIPTION
# PR Description

SDL_TICKS_PASSED is meant to compare 32-bit tick counts in a way that works correctly when the counter has recently wrapped around. The Python implementation just did a straight integer comparison. Fix it and add a regression test.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/marcusva/py-sdl2/blob/master/doc/news.rst
