### PR TITLE
sdlmixer_test: Accept a lower value for sample MP3 duration

### DIFF
--- a/sdl2/test/sdlmixer_test.py
+++ b/sdl2/test/sdlmixer_test.py
@@ -455,7 +455,9 @@ def test_Mix_MusicDuration(with_music):
     mus = with_music
     duration = sdlmixer.Mix_MusicDuration(mus)
     assert duration != 0
-    assert 0.2 < duration < 0.21
+    # NOTE: Actually about 0.15s, but the dr_mp3 backend in SDL_mixer
+    # reports it as just over 0.2s
+    assert 0.14 < duration < 0.21
 
 @pytest.mark.skip("not implemented")
 def test_Mix_GetMusicLoopStartTime(with_sdl_mixer):


### PR DESCRIPTION
All the decoders I've tried think sdl2/test/resources/soundtest.mp3
is approximately 0.15 seconds long.

Resolves: https://github.com/py-sdl/py-sdl2/issues/243

---

# PR Description

This fixes a test failure with SDL_mixer 2.6.1 compiled to use libmpg123 for MP3. Debian's versions of `extract(1)` and Audacity agree that the test file is about 0.15 seconds long.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
