### PR TITLE
version_test: Don't assert that SDL_GetRevision() starts with http

### DIFF
--- a/sdl2/test/version_test.py
+++ b/sdl2/test/version_test.py
@@ -57,7 +57,8 @@ def test_SDL_GetRevision():
     # If revision not empty string (e.g. Conda), test the prefix
     if len(rev):
         if dll.version_tuple >= (2, 0, 16):
-            assert rev[0:4] == b"http"
+            if rev[0:4] not in (b"http", b"SDL-"):
+                pytest.xfail("no API guarantee about the format of this string")
         else:
             assert rev[0:3] == b"hg-"
 


### PR DESCRIPTION
The default format is going to change in 2.25.x, and in git main it currently starts with "SDL-".

SDL specifically documents the result of this function as "not intended to be reliable in any way", so it seems wrong to have pysdl2's tests fail whenever the format changes. To address that, turn unexpected formats into an xfail, so that they're flagged as something to investigate but do not make the unit tests fail when used as a QA gate.

Closes: https://github.com/py-sdl/py-sdl2/issues/248

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
