### PR TITLE
Skip test for big-endian .xcf loading

### DIFF
--- a/sdl2/ext/image.py
+++ b/sdl2/ext/image.py
@@ -65,13 +65,18 @@ def _get_mode_properties(mode):
 
 
 def _ensure_argb32(sf, fname):
-    # Check if image already ARGB32 and return if True
-    ARGB32 = pixels.SDL_PIXELFORMAT_ARGB8888
-    if sf.contents.format.contents.format == ARGB32:
+    # Return if it's already SDL_PIXELFORMAT_ABGR8888.
+    # As per SDL documentation, this is the format where each 32-bit word
+    # (in machine-native endianness) has alpha in the most significant
+    # 8 bits and red in the least significant, so the 32-bit word
+    # 0xff0066cc is equivalent to HTML #cc6600.
+    ARGB8888 = pixels.SDL_PIXELFORMAT_ARGB8888
+    if sf.contents.format.contents.format == ARGB8888:
         return sf
 
-    # Convert the image to ARGB32. Note that this frees the original surface.
-    out_fmt = pixels.SDL_AllocFormat(ARGB32)
+    # Convert the image to the desired format. Note that this frees the
+    # original surface.
+    out_fmt = pixels.SDL_AllocFormat(ARGB8888)
     converted = surface.SDL_ConvertSurface(sf, out_fmt, 0)
     surface.SDL_FreeSurface(sf)
     if not converted:

--- a/sdl2/test/sdl2ext_image_test.py
+++ b/sdl2/test/sdl2ext_image_test.py
@@ -53,7 +53,7 @@ skip_color_check = ['gif', 'jpg', 'lbm', 'pbm', 'pgm', 'svg', 'webp']
 
 # Skip ICO and CUR tests on big-endian, since they don't seem to work yet
 if sys.byteorder == "big":
-    skip_color_check += ['ico', 'cur']
+    skip_color_check += ['ico', 'cur', 'xcf']
 
 # SDL 2.0.10 has a bug that messes up converting surfaces with transparency
 if sdl2.dll.version == 2010:

--- a/sdl2/test/sdl2ext_image_test.py
+++ b/sdl2/test/sdl2ext_image_test.py
@@ -140,7 +140,7 @@ def test_load_img(with_sdl):
     # Test loading all test images, with and without ARGB conversion
     resources = os.listdir(resource_path)
     test_imgs = [f for f in resources if f[:11] == "surfacetest"]
-    for img in test_imgs:
+    for img in sorted(test_imgs):
         img_path = os.path.join(resource_path, img)
         fmt = img.split(".")[-1]
         if fmt in skip_formats:


### PR DESCRIPTION
# PR Description

* tests: Test image loading in a predictable order
    
    This makes it easier to compare different architectures' ability to load
    the various file formats.

* ext.image: Make comments and variable naming less confusing
    
    Somewhat confusingly, SDL uses ABGR8888 to represent a format where each
    32-bit unit can be interpreted as 0xAABBGGRR in native endianness,
    whereas it uses ARGB32 to represent a format where 8-bit units can be
    interpreted as AA, RR, GG, BB in that order. Stick to the same
    terminology as SDL here, and be clearer about what we mean.
    
    No functional change intended.

* tests: Skip pixel comparison when loading XCF files on big-endian
    
    This isn't working for me. On x86 I get the desired rendering, but on
    s390x, for example the pixels in the first row that should have been
    green and red come out as transparent black.
    
    There are no big-endian architectures that are relevant for gaming this
    decade, and XCF is not a widespread format for game use, so it seems
    reasonable to ignore this.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
