### PR TITLE
Add new sdl2.ext module for handling SDL input events

### DIFF
--- a/doc/modules/ext/displays.rst
+++ b/doc/modules/ext/displays.rst
@@ -1,5 +1,5 @@
-`sdl2.ext.displays` - Getting info about the connected displays
-===============================================================
+`sdl2.ext.displays` - Querying the Connected Displays
+=====================================================
 
 This module provides the ``get_displays`` function, which returns a list of
 ``DisplayInfo`` objects containing information about the names, supported

--- a/doc/modules/ext/input.rst
+++ b/doc/modules/ext/input.rst
@@ -1,0 +1,21 @@
+`sdl2.ext.input` - Handling SDL2 Input Events
+=============================================
+
+This module provides a range of Pythonic functions for handling and processing
+SDL input events (e.g. key presses, mouse clicks, unicode text input) as
+retrieved from :func:`~sdl2.ext.get_events`.
+
+The :func:`key_pressed` function allows for easily checking whether a given key
+has been pressed (or released). Likewise, :func:`mouse_clicked` lets you handle
+mouse button press and release events. If you want to check the `locations` of
+mouse clicks, :func:`get_clicks` returns the pixel coordinates for all clicks
+(if any) in a given list of events.
+
+For handling text entry in PySDL2 (including unicode characters),
+:func:`get_text_input` returns all text input in a given list of events as a
+unicode string. Note that text input events are disabled by default in SDL, but
+can easily be enabled/disabled using :func:`start_text_input` and
+:func:`stop_text_input`.
+
+.. automodule:: sdl2.ext.input
+	:members:

--- a/doc/modules/sdl2ext.rst
+++ b/doc/modules/sdl2ext.rst
@@ -60,13 +60,14 @@ SDL2-based extensions
 ---------------------
 
 In addition to simple Pythonic wrappers for SDL2 functions and structures, the
-:mod:`sdl2.ext` module also offers a number of  high-level classes and functions
-that use SDL2 internally to provide APIs for font rendering, building GUIs,
-importing images, and more:
+:mod:`sdl2.ext` module also offers a number of high-level classes and functions
+that use SDL2 internally to provide APIs for font rendering, handling input
+events, importing images, and more:
 
 .. toctree::
 	:maxdepth: 1
 
+	ext/input.rst
 	ext/surface.rst
 	ext/draw.rst
 	ext/image.rst

--- a/doc/news.rst
+++ b/doc/news.rst
@@ -5,6 +5,22 @@ This describes the latest changes between the PySDL2 releases.
 0.9.16 (Unreleased)
 -------------------
 
+New Features:
+
+* Added a new function :func:`~sdl2.ext.key_pressed` for easily checking
+  if a given key has been pressed (or released).
+* Added a new function :func:`~sdl2.ext.mouse_clicked` for easily checking
+  if a mouse button has been pressed (or released), as well as a
+  :func:`~sdl2.ext.get_clicks` function for retrieving the pixel coordinates
+  of any mouse clicks.
+* Added a new function :func:`~sdl2.ext.get_text_input` for returning
+  text input as a unicode string, as well as :func:`~sdl2.ext.start_text_input`,
+  :func:`~sdl2.ext.stop_text_input`, and :func:`~sdl2.ext.text_input_enabled`
+  functions for toggling and querying whether SDL text input events are enabled.
+* Added a new function :func:`~sdl2.ext.quit_requested` for easily checking
+  :func:`~sdl2.ext.get_events` output for quit requests.
+
+
 0.9.15
 ------
 
@@ -21,7 +37,7 @@ New Features:
 * Added a new function :func:`~sdl2.ext.mouse_delta` for checking the relative
   movement of the mouse cursor since last checked.
 * Added a new function :func:`~sdl2.ext.mouse_button_state` and corresponding
-  class :class:`~sdl2.ext.ButtonState` for easily  checking the current state
+  class :class:`~sdl2.ext.ButtonState` for easily checking the current state
   of the mouse buttons.
 * Added indexing support for :class:`sdl2.SDL_Point` and :class:`sdl2.SDL_Rect`
   to allow easier unpacking in Python (e.g. ``x, y, w, h = rect``).

--- a/examples/draw.py
+++ b/examples/draw.py
@@ -3,6 +3,7 @@ import sys
 from random import randint
 import sdl2
 import sdl2.ext
+from sdl2.ext import get_events, quit_requested, mouse_clicked
 
 # Draws random lines on the passed surface
 def draw_lines(surface, width, height):
@@ -71,27 +72,26 @@ def run():
     curindex = 0
     draw_lines(windowsurface, 800, 600)
 
-    # The event loop is nearly the same as we used in colorpalettes.py. If you
-    # do not know, what happens here, take a look at colorpalettes.py for a
-    # detailled description.
+    # The event loop is nearly the same as we used in colorpalettes.py, except
+    # that here we use some functions from sdl2.ext for handling mouse clicks
+    # and quit requests to make the code more Pythonic.
     running = True
     while running:
-        events = sdl2.ext.get_events()
-        for event in events:
-            if event.type == sdl2.SDL_QUIT:
-                running = False
-                break
-            if event.type == sdl2.SDL_MOUSEBUTTONDOWN:
-                curindex += 1
-                if curindex >= len(functions):
-                    curindex = 0
-                # In contrast to colorpalettes.py, our mapping table consists
-                # of functions and their arguments. Thus, we get the currently
-                # requested function and argument tuple and execute the
-                # function with the arguments.
-                func, args = functions[curindex]
-                func(*args)
-                break
+        events = get_events()
+        # Handle any quit requests
+        if quit_requested(events):
+            running = False
+        # If the mouse is clicked, switch to the next drawing function
+        if mouse_clicked(events):
+            curindex += 1
+            if curindex >= len(functions):
+                curindex = 0
+            # In contrast to colorpalettes.py, our mapping table consists
+            # of functions and their arguments. Thus, we get the currently
+            # requested function and argument tuple and execute the
+            # function with the arguments.
+            func, args = functions[curindex]
+            func(*args)
         window.refresh()
     sdl2.ext.quit()
     return 0

--- a/examples/ttf.py
+++ b/examples/ttf.py
@@ -10,7 +10,7 @@ import os
 import sys
 import sdl2.ext
 from sdl2.sdlttf import TTF_FontLineSkip
-from sdl2.ext import FontTTF, key_pressed, get_text_input
+from sdl2.ext import FontTTF, key_pressed, get_text_input, quit_requested
 
 filepath = os.path.abspath(os.path.dirname(__file__))
 RESOURCES = sdl2.ext.Resources(filepath, "resources")
@@ -72,10 +72,9 @@ def run():
         update_txt = False
         events = sdl2.ext.get_events()
 
-        for event in events:
-            if event.type == sdl2.SDL_QUIT:
-                running = False
-                break
+        if quit_requested(events):
+            running = False
+            break
 
         # Handle special keyboard events
         if key_pressed(events):

--- a/sdl2/ext/__init__.py
+++ b/sdl2/ext/__init__.py
@@ -27,3 +27,4 @@ from .surface import *
 from .window import *
 from .mouse import *
 from .displays import *
+from .input import *

--- a/sdl2/ext/common.py
+++ b/sdl2/ext/common.py
@@ -162,7 +162,7 @@ def quit_requested(events):
                 running = False
 
     Args:
-        events (list or :obj:`sdl2.SDL_Event`): A list of SDL events to check
+        events (list of :obj:`sdl2.SDL_Event`): A list of SDL events to check
             for quit requests.
 
     Returns:

--- a/sdl2/ext/common.py
+++ b/sdl2/ext/common.py
@@ -1,9 +1,14 @@
 import ctypes
-from .. import (events, timer, error, dll,
+from .. import (timer, error, dll,
     SDL_Init, SDL_InitSubSystem, SDL_Quit, SDL_QuitSubSystem, SDL_WasInit,
     SDL_INIT_VIDEO, SDL_INIT_AUDIO, SDL_INIT_TIMER, SDL_INIT_HAPTIC,
     SDL_INIT_JOYSTICK, SDL_INIT_GAMECONTROLLER, SDL_INIT_SENSOR, SDL_INIT_EVENTS,
 )
+from ..events import (
+    SDL_Event, SDL_PumpEvents, SDL_PeepEvents,  SDL_PollEvent,
+    SDL_QUIT, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT,
+)
+from .compat import isiterable
 from .err import raise_sdl_err
 
 _HASSDLTTF = True
@@ -17,7 +22,7 @@ try:
 except ImportError:
     _HASSDLIMAGE = False
 
-__all__ = ["init", "quit", "get_events", "TestEventProcessor"]
+__all__ = ["init", "quit", "get_events", "quit_requested", "TestEventProcessor"]
 
 
 _sdl_subsystems = {
@@ -125,19 +130,15 @@ def get_events():
         the event queue.
     
     """
-    events.SDL_PumpEvents()
+    SDL_PumpEvents()
 
     evlist = []
-    SDL_PeepEvents = events.SDL_PeepEvents
-
-    op = events.SDL_GETEVENT
-    first = events.SDL_FIRSTEVENT
-    last = events.SDL_LASTEVENT
-
     while True:
-        evarray = (events.SDL_Event * 10)()
-        ptr = ctypes.cast(evarray, ctypes.POINTER(events.SDL_Event))
-        ret = SDL_PeepEvents(ptr, 10, op, first, last)
+        evarray = (SDL_Event * 10)()
+        ptr = ctypes.cast(evarray, ctypes.POINTER(SDL_Event))
+        ret = SDL_PeepEvents(
+            ptr, 10, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT
+        )
         if ret <= 0:
             break
         evlist += list(evarray)[:ret]
@@ -145,6 +146,41 @@ def get_events():
             break
 
     return evlist
+
+
+def quit_requested(events):
+    """Checks for quit requests in a given event queue.
+
+    Quit requests occur when an SDL recieves a system-level quit signal (e.g
+    clicking the 'close' button on an SDL window, pressing Command-Q on macOS).
+    This function makes it easier to handle these events in your code::
+
+        running = True
+        while running:
+            events = sdl2.ext.get_events()
+            if quit_requested(events):
+                running = False
+
+    Args:
+        events (list or :obj:`sdl2.SDL_Event`): A list of SDL events to check
+            for quit requests.
+
+    Returns:
+        bool: True if a quit request has occurred, otherwise False.
+
+    """
+    # Ensure 'events' is iterable
+    if not isiterable(events):
+        events = [events]
+
+    # Check for any quit events in the queue
+    requested = False
+    for e in events:
+        if e.type == SDL_QUIT:
+            requested = True
+            break
+
+    return requested
 
 
 class TestEventProcessor(object):
@@ -160,12 +196,12 @@ class TestEventProcessor(object):
                 the test event loop.
         
         """
-        event = events.SDL_Event()
+        event = SDL_Event()
         running = True
         while running:
-            ret = events.SDL_PollEvent(ctypes.byref(event), 1)
+            ret = SDL_PollEvent(ctypes.byref(event), 1)
             if ret == 1:
-                if event.type == events.SDL_QUIT:
+                if event.type == SDL_QUIT:
                     running = False
                     break
             window.refresh()

--- a/sdl2/ext/input.py
+++ b/sdl2/ext/input.py
@@ -65,7 +65,7 @@ def _parse_keycode(key):
 
 
 def _mod_to_masks(mod):
-    
+
     if not isiterable(mod):
         mod = [mod]
     
@@ -188,9 +188,11 @@ def key_pressed(events, key=None, mod=None, released=False):
         if e.type == (SDL_KEYUP if released else SDL_KEYDOWN):
             if not keycode:
                 pressed = True
+                break
             elif e.key.keysym.sym == keycode:
                 if not mod or all([e.key.keysym.mod & m for m in mod]):
                     pressed = True
+                    break
 
     return pressed
 
@@ -249,6 +251,7 @@ def mouse_clicked(events, button=None, released=False):
         if e.type == (SDL_MOUSEBUTTONUP if released else SDL_MOUSEBUTTONDOWN):
             if not button or e.button.button == button:
                 clicked = True
+                break
 
     return clicked
 

--- a/sdl2/ext/input.py
+++ b/sdl2/ext/input.py
@@ -16,8 +16,8 @@ from ..events import (
 from .compat import _is_text, byteify, isiterable
 
 __all__ = [
-    "start_text_input", "stop_text_input", "text_input_enabled",
-    "get_text_input", "key_pressed", "mouse_clicked", "get_clicks"
+    "key_pressed", "mouse_clicked", "get_clicks", "get_text_input",
+    "start_text_input", "stop_text_input", "text_input_enabled",  
 ]
 
 
@@ -154,7 +154,7 @@ def key_pressed(events, key=None, mod=None, released=False):
     https://wiki.libsdl.org/SDL_Keycode
 
     Args:
-        events (list or :obj:`sdl2.SDL_Event`): A list of SDL events to check
+        events (list of :obj:`sdl2.SDL_Event`): A list of SDL events to check
             for matching key presses (or releases).
         key (str or :obj:`sdl2.SDL_Keycode`, optional): The name or SDL keycode
             of the key to check. If ``None``, will return True on any keypress.
@@ -162,8 +162,8 @@ def key_pressed(events, key=None, mod=None, released=False):
         mod (str or list, optional): The key modifiers (if any) to require for
             the key press (e.g. 'ctrl' for Control-Q). Has no effect if ``key``
             is not specified. Defaults to ``None``.
-        released (bool, optional): If ``True``, will check for key release
-            events instead of key presses. Defaults to ``False``.
+        released (bool, optional): If True, will check for key release
+            events instead of key presses. Defaults to False.
 
     Returns:
         bool: True if key has been pressed, otherwise False.
@@ -225,13 +225,13 @@ def mouse_clicked(events, button=None, released=False):
     ===================== =============
 
     Args:
-        events (list or :obj:`sdl2.SDL_Event`): A list of SDL events to check
+        events (list of :obj:`sdl2.SDL_Event`): A list of SDL events to check
             for mouse click events.
         button (str or int, optional): The name or SDL constant of the mouse
             button to listen for. If ``None``, all mouse buttons will . Defaults to ``None``.
-        released (bool, optional): If ``True``, will check the queue for mouse
+        released (bool, optional): If True, will check the queue for mouse
             button release events instead of mouse button down events. Defaults
-            to ``False``.
+            to False.
 
     Returns:
         bool: True if the mouse has been clicked, otherwise False.
@@ -264,17 +264,17 @@ def get_clicks(events, button=None, released=False):
     SDL button constant (see :func:`mouse_clicked` for details).
 
     Args:
-        events (list or :obj:`sdl2.SDL_Event`): A list of SDL events to check
+        events (list of :obj:`sdl2.SDL_Event`): A list of SDL events to check
             for mouse click events.
         button (str or int, optional): The name or SDL constant of the mouse
             button to listen for. If ``None``, will return clicks from any mouse
             button. Defaults to ``None``.
-        released (bool, optional): If ``True``, will return the coordinates for
+        released (bool, optional): If True, will return the coordinates for
             mouse button release events instead of mouse button click events.
-            Defaults to ``False``.
+            Defaults to False.
 
     Returns:
-        list: A list of the ``(x, y)`` coordinates for each matching click event
+        list: A list of the (x, y) coordinates for each matching click event
         in the queue.
     
     """
@@ -343,7 +343,7 @@ def get_text_input(events):
     string will be returned.
 
     Args:
-        events (list or :obj:`sdl2.SDL_Event`): A list of SDL events to check
+        events (list of :obj:`sdl2.SDL_Event`): A list of SDL events to check
             for unicode text input (``SDL_TEXTINPUT``) events.
 
     Returns:

--- a/sdl2/ext/input.py
+++ b/sdl2/ext/input.py
@@ -1,0 +1,366 @@
+from ..stdinc import SDL_TRUE
+from ..keyboard import (
+    SDL_GetKeyFromName, SDL_GetKeyName, SDL_StartTextInput, SDL_StopTextInput,
+    SDL_IsTextInputActive,
+)
+from ..keycode import KMOD_ALT, KMOD_CTRL, KMOD_GUI, KMOD_SHIFT
+from ..mouse import (
+    SDL_BUTTON_LEFT, SDL_BUTTON_RIGHT, SDL_BUTTON_MIDDLE,
+    SDL_BUTTON_X1, SDL_BUTTON_X2,
+)
+from ..events import (
+    SDL_KEYDOWN, SDL_KEYUP, SDL_MOUSEBUTTONDOWN, SDL_MOUSEBUTTONUP,
+    SDL_TEXTINPUT,
+)
+
+from .compat import _is_text, byteify, isiterable
+
+__all__ = [
+    "start_text_input", "stop_text_input", "text_input_enabled",
+    "get_text_input", "key_pressed", "mouse_clicked", "get_clicks"
+]
+
+
+KEYMOD_MAP = {
+    # main mappings
+    'ctrl': KMOD_CTRL,
+    'alt': KMOD_ALT,
+    'gui': KMOD_GUI,
+    'shift': KMOD_SHIFT,
+    # additional aliases
+    'control': KMOD_CTRL,
+    'option': KMOD_ALT,
+    'command': KMOD_GUI,
+    'super': KMOD_GUI,
+}
+
+MOUSE_BUTTON_MAP = {
+    'left': SDL_BUTTON_LEFT,
+    'right': SDL_BUTTON_RIGHT,
+    'middle': SDL_BUTTON_MIDDLE,
+    'x1': SDL_BUTTON_X1,
+    'x2': SDL_BUTTON_X2,
+}
+
+
+
+def _parse_keycode(key):
+
+    keycode = 0
+    if isinstance(key, int):
+        if SDL_GetKeyName(key) == b"":
+            raise ValueError("'{0}' is not a valid SDL_Keycode".format(key))
+        keycode = key
+
+    elif _is_text(key):
+        keycode = SDL_GetKeyFromName(byteify(key))
+        if keycode == 0:
+            raise ValueError("'{0}' is not a valid SDL key name".format(key))
+        
+    else:
+        e = "'key' must be a string or SDL_Keycode (got {0})"
+        raise TypeError(e.format(str(type(key))))
+    
+    return keycode
+
+
+def _mod_to_masks(mod):
+    
+    if not isiterable(mod):
+        mod = [mod]
+    
+    masks = []
+    for m in mod:
+        # If mod is already an int, assume it's a valid bitmask
+        if isinstance(m, int):
+            masks.append(m)
+
+        # If mod is a string, validate and convert it to a bitmask
+        elif _is_text(m):
+            m = m.lower()
+            if not m in KEYMOD_MAP.keys():
+                e = "'{0}' is not a valid modifer key name"
+                raise ValueError(e.format(m))
+            masks.append(KEYMOD_MAP[m])
+
+        else:
+            e = "'mod' must be a list of strings or SDL bitmasks (got {0})"
+            raise TypeError(e.format(str(type(m))))
+    
+    return masks
+
+
+def _get_sdl_mouse_button(button):
+    
+    # Check if valid SDL_BUTTON constant
+    if isinstance(button, int):
+        if not button in MOUSE_BUTTON_MAP.values():
+            e = "'{0}' does not correspond to a valid SDL mouse button"
+            raise ValueError(e.format(button))
+    
+    # Check if valid mouse button name
+    elif _is_text(button):
+        button = button.lower()
+        if not button in MOUSE_BUTTON_MAP.keys():
+            e = "'{0}' is not a valid mouse button name"
+            raise ValueError(e.format(button))
+        button = MOUSE_BUTTON_MAP[button]
+
+    else:
+        e = "'button' must be a string or SDL_BUTTON constant (got {0})"
+        raise TypeError(e.format(str(type(button))))
+    
+    return button
+
+
+
+def key_pressed(events, key=None, mod=None, released=False):
+    """Checks for key press events in a given event queue.
+    
+    By default, this function will return True if any key has been pressed.
+    However, you can also check a specific key by providing its name (e.g.
+    'up') or SDL keycode (e.g. ``sdl2.SDLK_up``) to the 'key' argument.
+
+    This function is meant to be used with :func:`~sdl2.ext.get_events`::
+
+        response = None
+        while not response:
+            q = get_events() # Fetch latest SDL input events
+            if key_pressed(q, 'z'):
+                response = 'left'
+            elif key_pressed(q, '/'):
+                response = 'right'
+
+    Additionally, you can check if the key has been pressed while holding one
+    or more modifier keys (e.g. control + q to quit the program) by providing
+    the name(s) (e.g. 'ctrl') or SDL bitmask(s) (e.g. ``sdl2.KMOD_LCTRL``)
+    of the modifiers to the 'mod' argument::
+
+        q = get_events()
+        if key_pressed(q, 'q', mod='ctrl'):
+            exit_app()
+        elif key_pressed(q, 'd', mod=['ctrl', 'shift']):
+            debug_mode = True
+
+    Valid modifier names include 'ctrl' and 'control' for the Control keys,
+    'alt' and 'option' for the Alt keys, 'gui', 'command', and 'super' for the
+    Command/Win/Super keys, and 'shift' for the shift keys. A full list of SDL
+    modifier bitmasks can be found here: https://wiki.libsdl.org/SDL2/SDL_Keymod
+    
+    For a comprehensive list of valid key names, see the 'Name' column of the
+    following table: https://wiki.libsdl.org/SDL2/SDL_Scancode
+
+    For a comprehensive list of valid SDL keycodes, consult the following table:
+    https://wiki.libsdl.org/SDL_Keycode
+
+    Args:
+        events (list or :obj:`sdl2.SDL_Event`): A list of SDL events to check
+            for matching key presses (or releases).
+        key (str or :obj:`sdl2.SDL_Keycode`, optional): The name or SDL keycode
+            of the key to check. If ``None``, will return True on any keypress.
+            Defaults to ``None``.
+        mod (str or list, optional): The key modifiers (if any) to require for
+            the key press (e.g. 'ctrl' for Control-Q). Has no effect if ``key``
+            is not specified. Defaults to ``None``.
+        released (bool, optional): If ``True``, will check for key release
+            events instead of key presses. Defaults to ``False``.
+
+    Returns:
+        bool: True if key has been pressed, otherwise False.
+
+    """
+    # If key specified, validate and coerce to SDL_Keycode
+    keycode = None
+    if key:
+        keycode = _parse_keycode(key)
+        
+    # If modifier key(s) specified, validate and coerce to list of bitmasks
+    if mod:
+        mod = _mod_to_masks(mod)
+        
+    # Ensure 'events' is iterable
+    if not isiterable(events):
+        events = [events]
+
+    # Check for any key events matching the criteria in the given event queue
+    pressed = False
+    for e in events:
+        if e.type == (SDL_KEYUP if released else SDL_KEYDOWN):
+            if not keycode:
+                pressed = True
+            elif e.key.keysym.sym == keycode:
+                if not mod or all([e.key.keysym.mod & m for m in mod]):
+                    pressed = True
+
+    return pressed
+
+
+def mouse_clicked(events, button=None, released=False):
+    """Checks for any mouse clicks in a given event queue.
+
+    This function is meant to be used with :func:`~sdl2.ext.get_events`::
+
+        response = None
+        while not response:
+            q = get_events() # Fetch latest SDL input events
+            if mouse_clicked(q, 'left'):
+                response = 'left'
+            elif mouse_clicked(q, 'right'):
+                response = 'right'
+
+    By default, this function checks for clicks from any button. However, you
+    can also check for clicks from a specific button by specifying one of the
+    following strings or SDL constants for the ``button`` argument:
+
+    ===================== =============
+    SDL Constant          String
+    ===================== =============
+    ``SDL_BUTTON_LEFT``   ``'left'``
+    ``SDL_BUTTON_RIGHT``  ``'right'``
+    ``SDL_BUTTON_MIDDLE`` ``'middle'``
+    ``SDL_BUTTON_X1``     ``'x1'``
+    ``SDL_BUTTON_X2``     ``'x2'``
+    ===================== =============
+
+    Args:
+        events (list or :obj:`sdl2.SDL_Event`): A list of SDL events to check
+            for mouse click events.
+        button (str or int, optional): The name or SDL constant of the mouse
+            button to listen for. If ``None``, all mouse buttons will . Defaults to ``None``.
+        released (bool, optional): If ``True``, will check the queue for mouse
+            button release events instead of mouse button down events. Defaults
+            to ``False``.
+
+    Returns:
+        bool: True if the mouse has been clicked, otherwise False.
+
+    """
+    # If button specified, validate and coerce to SDL_BUTTON constant
+    if button:
+        button = _get_sdl_mouse_button(button)
+
+    # Ensure 'events' is iterable
+    if not isiterable(events):
+        events = [events]
+
+    # Check for any click events matching the criteria in the given event queue
+    clicked = False
+    for e in events:
+        if e.type == (SDL_MOUSEBUTTONUP if released else SDL_MOUSEBUTTONDOWN):
+            if not button or e.button.button == button:
+                clicked = True
+
+    return clicked
+
+
+def get_clicks(events, button=None, released=False):
+    """Returns the (x, y) coordinates of the mouse clicks in an event queue.
+
+    By default, this function returns clicks from any button. However, you can
+    also return clicks from a specific button only by specifying a string or
+    SDL button constant (see :func:`mouse_clicked` for details).
+
+    Args:
+        events (list or :obj:`sdl2.SDL_Event`): A list of SDL events to check
+            for mouse click events.
+        button (str or int, optional): The name or SDL constant of the mouse
+            button to listen for. If ``None``, will return clicks from any mouse
+            button. Defaults to ``None``.
+        released (bool, optional): If ``True``, will return the coordinates for
+            mouse button release events instead of mouse button click events.
+            Defaults to ``False``.
+
+    Returns:
+        list: A list of the ``(x, y)`` coordinates for each matching click event
+        in the queue.
+    
+    """
+    # If button specified, validate and coerce to SDL_BUTTON constant
+    if button:
+        button = _get_sdl_mouse_button(button)
+
+    # Ensure 'events' is iterable
+    if not isiterable(events):
+        events = [events]
+
+    # Gather and return any matching mouse clicks in the given queue
+    clicks = []
+    for e in events:
+        if e.type == (SDL_MOUSEBUTTONUP if released else SDL_MOUSEBUTTONDOWN):
+            if not button or e.button.button == button:
+                clicks.append((e.button.x, e.button.y))
+
+    return clicks
+
+
+def start_text_input():
+    """Enables SDL unicode text input events.
+
+    """
+    SDL_StartTextInput()
+
+
+def stop_text_input():
+    """Disables SDL unicode text input events.
+
+    """
+    SDL_StopTextInput()
+
+
+def text_input_enabled():
+    """Checks whether SDL text input events are currently enabled.
+
+    Returns:
+        bool: True if text input events are enabled, otherwise False.
+
+    """
+    return SDL_IsTextInputActive() == SDL_TRUE
+
+
+def get_text_input(events):
+    """Returns the text input events from a queue as a unicode string.
+
+    Note that SDL text input events need to be enabled for this function to
+    work. This can be toggled with :func:`start_text_input` /
+    :func:`stop_text_input` and queried with :func:`text_input_enabled`::
+
+        start_text_input()
+
+        response = u""
+        while True:
+            q = get_events()
+            if key_pressed(q, 'return'):
+                break
+            response += get_text_input(q)
+            draw_text(response)
+
+        stop_text_input()
+
+    If there are no text input events in the given event queue, an empty unicode
+    string will be returned.
+
+    Args:
+        events (list or :obj:`sdl2.SDL_Event`): A list of SDL events to check
+            for unicode text input (``SDL_TEXTINPUT``) events.
+
+    Returns:
+        str: A UTF8-encoded unicode string containing all text input from the
+        queue.
+
+    """
+    # Make sure text input events are enabled
+    if not text_input_enabled():
+        e = "Text input events must be enabled before using get_text()"
+        raise RuntimeError(e)
+
+    # Ensure 'events' is iterable
+    if not isiterable(events):
+        events = [events]
+
+    # Check for any key events matching the criteria in the given event queue
+    text = u""
+    for e in events:
+        if e.type == SDL_TEXTINPUT:
+            text += e.text.text.decode('utf-8')
+
+    return text

--- a/sdl2/test/sdl2ext_input_test.py
+++ b/sdl2/test/sdl2ext_input_test.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+import pytest
+from ..keycode import SDLK_a, KMOD_LSHIFT, KMOD_RCTRL
+from ..mouse import SDL_BUTTON_LEFT
+from ..events import (
+    SDL_Event, SDL_TEXTINPUT, SDL_MOUSEBUTTONUP, SDL_MOUSEBUTTONDOWN,
+    SDL_KEYDOWN, SDL_KEYUP,
+)
+from sdl2 import ext as sdl2ext
+from sdl2.ext.input import MOUSE_BUTTON_MAP, _parse_keycode
+
+
+@pytest.fixture(scope="module")
+def with_sdl():
+    sdl2ext.init()
+    yield
+    sdl2ext.quit()
+
+@pytest.fixture(scope="module")
+def with_ext_window(with_sdl):
+    win = sdl2ext.Window("Test", (100, 100))
+    win.show()
+    yield win
+    win.close()
+
+def textinput(char):
+    # Generate a simulated text input event
+    e = SDL_Event()
+    e.type = SDL_TEXTINPUT
+    e.text.type = SDL_TEXTINPUT
+    e.text.text = char.encode('utf-8')
+    return e
+
+def key(k, mod = 0, released = False):
+    e = SDL_Event()
+    e.type = SDL_KEYUP if released else SDL_KEYDOWN 
+    e.key.type = SDL_KEYUP if released else SDL_KEYDOWN 
+    e.key.keysym.sym = _parse_keycode(k)
+    e.key.keysym.mod = mod
+    return e
+
+def click(button = 'right', loc = (0, 0), release = False):
+    # Generate a simulated mouse click event
+    etype = SDL_MOUSEBUTTONUP if release else SDL_MOUSEBUTTONDOWN
+    e = SDL_Event()
+    e.type = etype
+    e.button.type = etype
+    e.button.x, e.button.y = loc
+    e.button.button = MOUSE_BUTTON_MAP[button]
+    return e
+
+
+def test_start_stop_text_input(with_ext_window):
+    # Try toggling text input
+    sdl2ext.stop_text_input()
+    assert not sdl2ext.text_input_enabled()
+    sdl2ext.start_text_input()
+    assert sdl2ext.text_input_enabled()
+    sdl2ext.stop_text_input()
+    assert not sdl2ext.text_input_enabled()
+
+
+def test_get_text_input(with_ext_window):
+    q = [
+        textinput("h"),
+        textinput("é"),
+        textinput("l"),
+        textinput("l"),
+        textinput("ø"),
+    ]
+    # Enable text input
+    sdl2ext.start_text_input()
+    assert sdl2ext.text_input_enabled()
+    # Test with empty queue
+    assert sdl2ext.get_text_input([]) == u""
+    # Test with simulated input
+    assert sdl2ext.get_text_input(q) == u"héllø"
+    # Test exception when text input disabled
+    sdl2ext.stop_text_input()
+    assert not sdl2ext.text_input_enabled()
+    with pytest.raises(RuntimeError):
+        sdl2ext.get_text_input(q)
+
+
+def test_key_pressed():
+    # Test with empty queue
+    assert sdl2ext.key_pressed([]) == False
+    # Test with simulated key events
+    q = [key('a'), key('b'), key('c', released=True)]
+    assert sdl2ext.key_pressed(q) == True
+    assert sdl2ext.key_pressed(q, 'a') == True
+    assert sdl2ext.key_pressed(q, SDLK_a) == True
+    assert sdl2ext.key_pressed(q, 'b') == True
+    assert sdl2ext.key_pressed(q, 'z') == False
+    assert sdl2ext.key_pressed(q, 'c') == False
+    assert sdl2ext.key_pressed(q, 'b', released=True) == False
+    assert sdl2ext.key_pressed(q, 'c', released=True) == True
+    # Test with modifier keys
+    q = [key('a'), key('b', mod=KMOD_LSHIFT), key('c', mod=(KMOD_LSHIFT|KMOD_RCTRL))]
+    assert sdl2ext.key_pressed(q, 'a', mod='shift') == False
+    assert sdl2ext.key_pressed(q, 'b', mod='shift') == True
+    assert sdl2ext.key_pressed(q, 'c', mod='shift') == True
+    assert sdl2ext.key_pressed(q, 'b', mod=KMOD_LSHIFT) == True
+    assert sdl2ext.key_pressed(q, 'b', mod=['ctrl', 'shift']) == False
+    assert sdl2ext.key_pressed(q, 'c', mod=['ctrl', 'shift']) == True
+    assert sdl2ext.key_pressed(q, 'c', mod=[KMOD_LSHIFT, KMOD_RCTRL]) == True
+    # Test with single event
+    assert sdl2ext.key_pressed(q[0], 'a') == True
+    # Test exception on bad buttons
+    with pytest.raises(ValueError):
+        sdl2ext.key_pressed(q, 'nope')
+    with pytest.raises(ValueError):
+        sdl2ext.key_pressed(q, key=-100)
+
+
+def test_mouse_clicked():
+    # Test with empty queue
+    assert sdl2ext.mouse_clicked([]) == False
+    # Test with simulated clicks
+    q = [
+        click('left'),
+        click('middle'),
+        click('right', release=True),
+    ]
+    assert sdl2ext.mouse_clicked(q) == True
+    assert sdl2ext.mouse_clicked(q, 'left') == True
+    assert sdl2ext.mouse_clicked(q, 'middle') == True
+    assert sdl2ext.mouse_clicked(q, 'right') == False
+    assert sdl2ext.mouse_clicked(q, 'left', released=True) == False
+    assert sdl2ext.mouse_clicked(q, 'right', released=True) == True
+    # Test with single event
+    assert sdl2ext.mouse_clicked(q[0], 'left') == True
+    # Test exception on bad buttons
+    with pytest.raises(ValueError):
+        sdl2ext.mouse_clicked(q, 'upper-middle')
+    with pytest.raises(ValueError):
+        sdl2ext.mouse_clicked(q, button=100)
+
+
+def test_get_clicks():
+    # Test with empty queue
+    assert sdl2ext.get_clicks([]) == []
+    # Test with simulated clicks
+    q = [
+        click('left', loc=(10, 20)),
+        click('left', loc=(30, 20)),
+        click('middle', loc=(100, 100)),
+        click('right', loc=(45, 432), release=True),
+    ]
+    assert sdl2ext.get_clicks(q) == [(10, 20), (30, 20), (100, 100)]
+    assert sdl2ext.get_clicks(q, 'left') == [(10, 20), (30, 20)]
+    assert sdl2ext.get_clicks(q, SDL_BUTTON_LEFT) == [(10, 20), (30, 20)]
+    assert sdl2ext.get_clicks(q, 'middle') == [(100, 100)]
+    assert sdl2ext.get_clicks(q, 'right') == []
+    assert sdl2ext.get_clicks(q, 'left', released=True) == []
+    assert sdl2ext.get_clicks(q, 'right', released=True) == [(45, 432)]
+    # Test with single event
+    assert sdl2ext.get_clicks(q[0], 'left') == [(10, 20)]
+    # Test exception on bad buttons
+    with pytest.raises(ValueError):
+        sdl2ext.get_clicks(q, 'upper-middle')
+    with pytest.raises(ValueError):
+        sdl2ext.get_clicks(q, button=100)

--- a/sdl2/test/sdl2ext_input_test.py
+++ b/sdl2/test/sdl2ext_input_test.py
@@ -62,11 +62,11 @@ def test_start_stop_text_input(with_ext_window):
 
 def test_get_text_input(with_ext_window):
     q = [
-        textinput("h"),
-        textinput("é"),
-        textinput("l"),
-        textinput("l"),
-        textinput("ø"),
+        textinput(u"h"),
+        textinput(u"é"),
+        textinput(u"l"),
+        textinput(u"l"),
+        textinput(u"ø"),
     ]
     # Enable text input
     sdl2ext.start_text_input()

--- a/sdl2/test/sdl2ext_test.py
+++ b/sdl2/test/sdl2ext_test.py
@@ -2,8 +2,10 @@ import sys
 import pytest
 import sdl2
 from sdl2 import ext as sdl2ext
-from sdl2 import SDL_Quit, SDL_WasInit, SDL_FlushEvent, SDL_USEREVENT, \
-    SDL_FIRSTEVENT, SDL_LASTEVENT, SDL_Event, SDL_UserEvent, SDL_PushEvent
+from sdl2 import (
+    SDL_Quit, SDL_WasInit, SDL_FlushEvent, SDL_UserEvent, SDL_PushEvent, 
+    SDL_Event, SDL_USEREVENT, SDL_FIRSTEVENT, SDL_LASTEVENT, SDL_QUIT,
+)
 
 @pytest.fixture(scope="module")
 def with_sdl_ext():
@@ -68,6 +70,15 @@ def test_get_events(with_sdl_ext):
     assert len(results) == 12
     for idx, r in enumerate(results):
         assert idx == r.type - SDL_USEREVENT
+
+def test_quit_requested(with_sdl_ext):
+    # Create a fake quit event
+    e = SDL_Event()
+    e.type = SDL_QUIT
+    # Test without any events
+    assert sdl2ext.quit_requested([]) == False
+    # Test with a quit event
+    assert sdl2ext.quit_requested([e]) == True
 
 def test_TestEventProcessor(with_sdl_ext):
     # NOTE: This doesn't really test functionality, but since I don't think


### PR DESCRIPTION
<!--Thanks for contributing to PySDL2!-->

# PR Description

This PR adds a new `sdl2.ext` module with a series of functions that allow Pythonic handling of SDL input events without needing to deal directly with `SDL_Event` loops, as well as an additional function in `sdl2.ext.common` for specifically handling quit requests. The current PR contains functions for handling keypress, mouse click, and text input events, but joystick/controller events will hopefully be added in a future update.

In general, these new functions should make it faster and easier for SDL2 beginners (and veterans) to write clean, readable input processing loops while also allowing a great deal of flexibility.


# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [x] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
