### PR TITLE
Make the build reproducible

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,8 +2,9 @@
 
 import os
 import sys
+import time
+import datetime
 import pkg_resources
-from datetime import date
 
 # -- Path setup --------------------------------------------------------------
 
@@ -17,7 +18,9 @@ sys.path.append(os.path.join(parent_dir, "sdl2", "ext"))
 
 # -- Project information -----------------------------------------------------
 
-curr_date = date.today()
+curr_date = datetime.datetime.utcfromtimestamp(
+    int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+).date()
 copyright_str = '{0}, Marcus von Appen. Last updated: {1}'
 
 project = 'PySDL2'


### PR DESCRIPTION
From: Chris Lamb

The goal of reproducible builds is that a rebuild of the same source code with the same compiler, libraries, etc. should result in the same binaries. SOURCE_DATE_EPOCH provides a standard way for build systems to fill in the date of the latest source change, typically from a git commit or from metadata like the debian/changelog in Debian packages.

This does not change anything if SOURCE_DATE_EPOCH is not defined; the intention is that a larger build system like a Debian package will define it.

Please see https://reproducible-builds.org/ for more information about reproducible builds.

Bug-Debian: https://bugs.debian.org/1031412

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
