### PR TITLE
Improve unit tests and restore Python 2.7 CI runners

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,6 +12,39 @@ on:
 
 jobs:
 
+  # Test on Python 2.7 with Linux and latest SDL2
+  test-linux-py27:
+
+    name: Linux (Python 2.7, SDL ${{ matrix.sdl2 }})
+    runs-on: ubuntu-20.04
+    container: python:2.7
+
+    strategy:
+      matrix:
+        sdl2: ['2.26.0']
+
+    env:
+      PYSDL2_DLL_VERSION: ${{ matrix.sdl2 }}
+      SDL_VIDEODRIVER: dummy
+      SDL_AUDIODRIVER: dummy
+      SDL_RENDER_DRIVER: software
+      PYTHONFAULTHANDLER: 1
+    
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies and latest SDL2 binaries
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install numpy pytest pillow
+          python -m pip install pysdl2-dll==$PYSDL2_DLL_VERSION
+
+      - name: Install and test PySDL2
+        run: |
+          python -m pip install .
+          python -B -m pytest -vvl -rxXP
+
+
   # Test on all supported Python versions with Linux and latest SDL2
   # Experimental: Also test on latest PyPy 2.7 and 3.x versions with Linux and latest SDL2
   test-linux:
@@ -47,39 +80,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies and latest SDL2 binaries
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install numpy pytest pillow
-          python -m pip install pysdl2-dll==$PYSDL2_DLL_VERSION
-
-      - name: Install and test PySDL2
-        run: |
-          python -m pip install .
-          python -B -m pytest -vvl -rxXP
-
-
-  # Test on Python 2.7 with Linux and latest SDL2
-  test-linux-py27:
-
-    name: Linux (Python 2.7, SDL ${{ matrix.sdl2 }})
-    runs-on: ubuntu-20.04
-    container: python:2.7
-
-    strategy:
-      matrix:
-        sdl2: ['2.26.0']
-
-    env:
-      PYSDL2_DLL_VERSION: ${{ matrix.sdl2 }}
-      SDL_VIDEODRIVER: dummy
-      SDL_AUDIODRIVER: dummy
-      SDL_RENDER_DRIVER: software
-      PYTHONFAULTHANDLER: 1
-    
-    steps:
-      - uses: actions/checkout@v2
 
       - name: Install dependencies and latest SDL2 binaries
         run: |
@@ -231,19 +231,19 @@ jobs:
 
       - name: Set up Python 2.7
         run: |
-          choco install python2
+          choco install python2 --x86
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install numpy pytest pillow
+          python2 -m pip install --upgrade pip
+          python2 -m pip install numpy pytest pillow
 
       - name: Download SDL2 binaries
         run: |
-          python .ci/getsdl2.py
+          python2 .ci/getsdl2.py
 
       - name: Install and test PySDL2
         run: |
           $env:PYSDL2_DLL_PATH = "$pwd\dlls"
-          python -m pip install .
-          python -B -m pytest -vvl -rxXP
+          python2 -m pip install .
+          python2 -B -m pytest -vvl -rxXP

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -232,19 +232,18 @@ jobs:
       - name: Set up Python 2.7
         run: |
           choco install python2 --x86
-          $env:PATH += ";C:\Python27"
 
       - name: Install dependencies
         run: |
-          python2.7 -m pip install --upgrade pip
-          python2.7 -m pip install numpy pytest pillow
+          C:\Python27\python -m pip install --upgrade pip
+          C:\Python27\python -m pip install numpy pytest pillow
 
       - name: Download SDL2 binaries
         run: |
-          python2.7 .ci/getsdl2.py
+          C:\Python27\python .ci/getsdl2.py
 
       - name: Install and test PySDL2
         run: |
           $env:PYSDL2_DLL_PATH = "$pwd\dlls"
-          python2.7 -m pip install .
-          python2.7 -B -m pytest -vvl -rxXP
+          C:\Python27\python -m pip install .
+          C:\Python27\python -B -m pytest -vvl -rxXP

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -232,18 +232,19 @@ jobs:
       - name: Set up Python 2.7
         run: |
           choco install python2 --x86
+          refreshenv
 
       - name: Install dependencies
         run: |
-          python2 -m pip install --upgrade pip
-          python2 -m pip install numpy pytest pillow
+          python2.7 -m pip install --upgrade pip
+          python2.7 -m pip install numpy pytest pillow
 
       - name: Download SDL2 binaries
         run: |
-          python2 .ci/getsdl2.py
+          python2.7 .ci/getsdl2.py
 
       - name: Install and test PySDL2
         run: |
           $env:PYSDL2_DLL_PATH = "$pwd\dlls"
-          python2 -m pip install .
-          python2 -B -m pytest -vvl -rxXP
+          python2.7 -m pip install .
+          python2.7 -B -m pytest -vvl -rxXP

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Set up Python 2.7
         run: |
           choco install python2 --x86
-          refreshenv
+          set PATH=%PATH%;C:\Python27
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         sdl2: ['2.26.0']
         name-prefix: ['Linux (Python ']
         include:
@@ -60,8 +60,40 @@ jobs:
           python -B -m pytest -vvl -rxXP
 
 
+  # Test on Python 2.7 with Linux and latest SDL2
+  test-linux-py27:
+
+    name: Linux (Python 2.7, SDL ${{ matrix.sdl2 }})
+    runs-on: ubuntu-20.04
+    container: python:2.7
+
+    strategy:
+      matrix:
+        sdl2: ['2.26.0']
+
+    env:
+      PYSDL2_DLL_VERSION: ${{ matrix.sdl2 }}
+      SDL_VIDEODRIVER: dummy
+      SDL_AUDIODRIVER: dummy
+      SDL_RENDER_DRIVER: software
+      PYTHONFAULTHANDLER: 1
+    
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies and latest SDL2 binaries
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install numpy pytest pillow
+          python -m pip install pysdl2-dll==$PYSDL2_DLL_VERSION
+
+      - name: Install and test PySDL2
+        run: |
+          python -m pip install .
+          python -B -m pytest -vvl -rxXP
+
+
   # Test on previous Python release with last 3 SDL2 releases on macOS
-  # Also test on Python 2.7 with latest SDL2 on macOS
   # All tests run without Numpy/Pillow deps to make sure things work without them
   # Experimental: Test on previous Python release with latest Homebrew SDL2
   test-macos:
@@ -76,9 +108,6 @@ jobs:
         sdl2: ['2.26.0', '2.24.0', '2.0.22']
         name-prefix: ['macOS (Python ']
         include:
-          - python-version: '2.7'
-            sdl2: '2.26.0'
-            name-prefix: 'macOS (Python '
           - python-version: '3.10'
             sdl2: 'from Homebrew'
             name-prefix: 'Experimental / macOS (Python '
@@ -135,31 +164,15 @@ jobs:
         ]
         name-prefix: ['Windows (Python ']
         include:
-          - python-version: '2.7'
-            architecture: 'x64'
-            sdl2: '2.26.0'
-            name-prefix: 'Windows (Python '
-          - python-version: '2.7'
+          - python-version: '3.8'
             architecture: 'x86'
             sdl2: '2.26.0'
             name-prefix: 'Windows 32-bit (Python '
-          - python-version: '3.10'
-            architecture: 'x86'
-            sdl2: '2.26.0'
-            name-prefix: 'Windows 32-bit (Python '
-          - python-version: '2.7'
+          - python-version: '3.8'
             architecture: 'x86'
             sdl2: '2.0.22'
             name-prefix: 'Windows 32-bit (Python '
-          - python-version: '2.7'
-            architecture: 'x86'
-            sdl2: '2.0.9'
-            name-prefix: 'Windows 32-bit (Python '
-          - python-version: '2.7'
-            architecture: 'x86'
-            sdl2: '2.0.7'
-            name-prefix: 'Windows 32-bit (Python '
-          - python-version: '2.7'
+          - python-version: '3.8'
             architecture: 'x86'
             sdl2: '2.0.5'
             name-prefix: 'Windows 32-bit (Python '
@@ -178,6 +191,47 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install numpy pytest pillow
+
+      - name: Download SDL2 binaries
+        run: |
+          python .ci/getsdl2.py
+
+      - name: Install and test PySDL2
+        run: |
+          $env:PYSDL2_DLL_PATH = "$pwd\dlls"
+          python -m pip install .
+          python -B -m pytest -vvl -rxXP
+
+
+  # Test select versions of SDL2 on Windows with Python 2.7
+  test-windows-py27:
+
+    name: Windows 32-bit (Python 2.7, SDL ${{ matrix.sdl2 }})
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture: ['x86']
+        sdl2: ['2.26.0', '2.0.5']
+
+    env:
+      PYSDL2_DLL_VERSION: ${{ matrix.sdl2 }}
+      SDL_VIDEODRIVER: dummy
+      SDL_AUDIODRIVER: dummy
+      SDL_RENDER_DRIVER: software
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 2.7
+        run: |
+          choco install python2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Set up Python 2.7
         run: |
           choco install python2 --x86
-          set PATH=%PATH%;C:\Python27
+          $env:PATH += ";C:\Python27"
 
       - name: Install dependencies
         run: |

--- a/sdl2/ext/mouse.py
+++ b/sdl2/ext/mouse.py
@@ -176,6 +176,10 @@ def warp_mouse(x, y, window=None, desktop=False):
     the cursor can be warped within a specific SDL window or relative to the
     full desktop.
 
+    .. NOTE: For security reasons, the Wayland protocol does not allow programs
+             to change the cursor position. However, it is possible to warp the
+             cursor when using XWayland (the default for SDL2).
+
     Args:
         x (int): The new X position for the mouse cursor.
         y (int): The new Y position for the mouse cursor.

--- a/sdl2/test/audio_test.py
+++ b/sdl2/test/audio_test.py
@@ -7,6 +7,7 @@ from sdl2 import SDL_Init, SDL_Quit, SDL_InitSubSystem, SDL_QuitSubSystem, \
     SDL_INIT_AUDIO
 from sdl2.audio import FORMAT_NAME_MAP
 from sdl2.error import SDL_GetError, SDL_ClearError
+from .conftest import _check_error_msg
 
 # NOTE: This module is missing a lot of tests, but is also going to be tricky
 # to write more tests for.
@@ -23,7 +24,7 @@ def with_sdl_audio():
     sdl2.SDL_Quit()
     sdl2.SDL_ClearError()
     ret = sdl2.SDL_Init(sdl2.SDL_INIT_VIDEO | sdl2.SDL_INIT_AUDIO)
-    assert ret == 0, sdl2.SDL_GetError().decode('utf-8', 'replace')
+    assert ret == 0, _check_error_msg()
     yield
     sdl2.SDL_Quit()
     # Reset original audio driver in environment
@@ -307,7 +308,7 @@ def test_SDL_GetDefaultAudioInfo(with_default_driver):
     # If method isn't implemented for the current back end, just skip
     if ret < 0 and b"not supported" in sdl2.SDL_GetError():
         pytest.skip("not supported by driver")
-    assert ret == 0, sdl2.SDL_GetError().decode('utf-8', 'replace')
+    assert ret == 0, _check_error_msg()
     # Validate frequency and channel count were set
     hz = outspec.freq
     fmt = FORMAT_NAME_MAP[outspec.format] if outspec.format > 0 else 'unknown'

--- a/sdl2/test/clipboard_test.py
+++ b/sdl2/test/clipboard_test.py
@@ -2,7 +2,7 @@ import sys
 import pytest
 import sdl2
 from sdl2 import SDL_GetError, SDL_TRUE, SDL_FALSE
-from .conftest import SKIP_ANNOYING
+from .conftest import SKIP_ANNOYING, _check_error_msg
 
 @pytest.fixture
 def window(with_sdl):
@@ -28,8 +28,7 @@ def test_SDL_ClipboardText(window):
     # Set some new clipboard text and test for it
     sdl2.SDL_ClearError()
     ret = sdl2.SDL_SetClipboardText(b"test")
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     assert sdl2.SDL_HasClipboardText() == SDL_TRUE
     assert sdl2.SDL_GetClipboardText() == b"test"
     # Reset original contents
@@ -48,8 +47,7 @@ def test_SDL_PrimarySelectionText(window):
     # Set some new primary selection text and test for it
     sdl2.SDL_ClearError()
     ret = sdl2.SDL_SetPrimarySelectionText(b"test")
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     assert sdl2.SDL_HasPrimarySelectionText() == SDL_TRUE
     assert sdl2.SDL_GetPrimarySelectionText() == b"test"
     # Reset original contents

--- a/sdl2/test/conftest.py
+++ b/sdl2/test/conftest.py
@@ -1,5 +1,6 @@
 # pytest configuration file
 import os
+import sys
 import gc
 import pytest
 import sdl2
@@ -8,6 +9,18 @@ from sdl2 import ext as sdl2ext
 # A flag to skip annoying audiovisual tests (e.g. window minimize).
 # Defaults to True unless an environment variable is explicitly set.
 SKIP_ANNOYING = os.getenv("PYSDL2_ALL_TESTS", "0") == "0"
+
+# Set a global constant identifying the current video driver
+SDL_VIDEODRIVER = "dummy"
+try:
+    sdl2.SDL_Init(sdl2.SDL_INIT_VIDEO)
+    SDL_VIDEODRIVER = sdl2.SDL_GetCurrentVideoDriver()
+    sdl2.SDL_Quit()
+    if sys.version_info[0] >= 3:
+        SDL_VIDEODRIVER = SDL_VIDEODRIVER.decode('utf-8')
+except:
+    pass
+
 
 @pytest.fixture(scope="module")
 def with_sdl():

--- a/sdl2/test/conftest.py
+++ b/sdl2/test/conftest.py
@@ -36,3 +36,11 @@ def sdl_cleanup():
     yield
     sdl2.SDL_ClearError()
     gc.collect()
+
+
+def _check_error_msg():
+    # Convenience function for retrieving the current SDL error as a str
+    e = sdl2.SDL_GetError()
+    if sys.version_info[0] >= 3:
+        e = e.decode('utf-8', 'replace')
+    return e

--- a/sdl2/test/filesystem_test.py
+++ b/sdl2/test/filesystem_test.py
@@ -10,7 +10,7 @@ def test_SDL_GetBasePath():
     path = path.decode("utf-8")
     if sys.version_info[0] < 3:
         is_python_path = False
-        for s in [u"python", u"pypy", u"pyenv", u"virtualenv"]:
+        for s in [u"python", u"pypy", u"pyenv", u"virtualenv", u"bin"]:
             if s in path.lower():
                 is_python_path = True
                 break

--- a/sdl2/test/gamecontroller_test.py
+++ b/sdl2/test/gamecontroller_test.py
@@ -6,6 +6,7 @@ from sdl2 import (
     SDL_FALSE, SDL_TRUE, SDL_IGNORE, SDL_ENABLE, SDL_QUERY
 )
 from sdl2 import joystick
+from .conftest import _check_error_msg
 
 # Get status of gamepad support/availability before running tests
 SDL_ClearError()
@@ -35,7 +36,7 @@ def with_sdl():
     sdl2.SDL_ClearError()
     sdl2.SDL_SetHint(b"SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS", b"1")
     ret = sdl2.SDL_Init(sdl2.SDL_INIT_VIDEO | sdl2.SDL_INIT_GAMECONTROLLER)
-    assert ret == 0, sdl2.SDL_GetError().decode('utf-8', 'replace')
+    assert ret == 0, _check_error_msg()
     # Also initialize a virtual joystick (if supported)
     if sdl2.dll.version >= 2014:
         virt_type = joystick.SDL_JOYSTICK_TYPE_GAMECONTROLLER

--- a/sdl2/test/hidapi_test.py
+++ b/sdl2/test/hidapi_test.py
@@ -3,6 +3,7 @@ import pytest
 import sdl2
 from sdl2.stdinc import SDL_TRUE, SDL_FALSE
 from sdl2.error import SDL_GetError, SDL_ClearError
+from .conftest import _check_error_msg
 
 # Make sure hidapi subsystem is available and works before running tests
 skipmsg = 'HIDAPI requires SDL 2.0.18 or newer'
@@ -19,18 +20,14 @@ def hidapi_setup():
     assert ret == 0
 
 
-# NOTE: Remove this xfail once libudev is officially removed from pysdl2-dll
-@pytest.mark.xfail("linux" in sys.platform, reason="udev problems")
 def test_SDL_hid_init_exit():
     SDL_ClearError()
     # Initialize the library
     ret = sdl2.SDL_hid_init()
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     # Exit the library
     ret = sdl2.SDL_hid_exit()
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
 
 
 def test_SDL_hid_device_change_count(hidapi_setup):

--- a/sdl2/test/hints_test.py
+++ b/sdl2/test/hints_test.py
@@ -3,13 +3,14 @@ import pytest
 from ctypes import cast, c_char_p
 import sdl2
 from sdl2.stdinc import SDL_TRUE, SDL_FALSE
+from .conftest import _check_error_msg
 
 # Need to override global fixture to init/quit on every test
 @pytest.fixture
 def with_sdl():
     sdl2.SDL_ClearError()
     ret = sdl2.SDL_Init(sdl2.SDL_INIT_VIDEO)
-    assert ret == 0, sdl2.SDL_GetError().decode('utf-8', 'replace')
+    assert ret == 0, _check_error_msg()
     yield
     sdl2.SDL_Quit()
 

--- a/sdl2/test/joystick_test.py
+++ b/sdl2/test/joystick_test.py
@@ -6,6 +6,7 @@ from sdl2 import SDL_Init, SDL_Quit, SDL_INIT_JOYSTICK
 from sdl2.events import SDL_QUERY, SDL_ENABLE, SDL_IGNORE
 from sdl2.stdinc import SDL_TRUE, SDL_FALSE
 from sdl2.error import SDL_GetError, SDL_ClearError
+from .conftest import _check_error_msg
 
 # Get status of joystick support/availability before running tests
 any_joysticks = False
@@ -42,7 +43,7 @@ def with_sdl():
     sdl2.SDL_ClearError()
     sdl2.SDL_SetHint(b"SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS", b"1")
     ret = sdl2.SDL_Init(sdl2.SDL_INIT_VIDEO | sdl2.SDL_INIT_JOYSTICK)
-    assert ret == 0, sdl2.SDL_GetError().decode('utf-8', 'replace')
+    assert ret == 0, _check_error_msg()
     # Also initialize a virtual joystick (if supported)
     if sdl2.dll.version >= 2014:
         virt_type = sdl2.SDL_JOYSTICK_TYPE_GAMECONTROLLER
@@ -474,8 +475,7 @@ def test_SDL_JoystickGetBall(joysticks):
     for stick in sticks:
         for ball in range(sdl2.SDL_JoystickNumBalls(stick)):
             ret = get_ball(stick, ball, byref(dx), byref(dy))
-            assert SDL_GetError() == b""
-            assert ret == 0
+            assert ret == 0, _check_error_msg()
 
 def test_SDL_JoystickGetButton(joysticks):
     for stick in joysticks:

--- a/sdl2/test/render_test.py
+++ b/sdl2/test/render_test.py
@@ -12,6 +12,7 @@ from sdl2.pixels import SDL_Color
 from sdl2 import video, surface, pixels, blendmode, rect
 from sdl2.ext.compat import byteify, stringify
 from sdl2.ext.pixelaccess import PixelView
+from .conftest import _check_error_msg
 
 # TODO: Write tests for more functions
 
@@ -210,9 +211,7 @@ def test_SDL_CreateWindowAndRenderer(with_sdl):
     )
     sdl2.SDL_DestroyRenderer(renderer)
     video.SDL_DestroyWindow(window)
-    if ret != 0:
-        assert SDL_GetError() == b""
-        assert ret == 0
+    assert ret == 0, _check_error_msg()
 
 def test_SDL_CreateDestroyRenderer(supported_renderers):
     flags = _get_renderflags()
@@ -379,8 +378,7 @@ def test_SDL_QueryTexture(with_renderer):
                 ret = sdl2.SDL_QueryTexture(
                     tx, byref(txf), byref(txa), byref(txw), byref(txh)
                 )
-                assert SDL_GetError() == b""
-                assert ret == 0
+                assert ret == 0, _check_error_msg()
                 assert txf.value == fmt
                 assert txa.value == acc
                 assert txw.value == w
@@ -400,25 +398,21 @@ def test_SDL_GetSetTextureColorMod(texture):
     ]
     for r, g, b in colors:
         ret = sdl2.SDL_SetTextureColorMod(texture, r, g, b)
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         tr, tg, tb = Uint8(0), Uint8(0), Uint8(0)
         ret = sdl2.SDL_GetTextureColorMod(
             texture, byref(tr), byref(tg), byref(tb)
         )
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         assert (tr.value, tg.value, tb.value) == (r, g, b)
 
 def test_SDL_GetSetTextureAlphaMod(texture):
     for alpha in range(0, 255, 7):
         ret = sdl2.SDL_SetTextureAlphaMod(texture, alpha)
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         talpha = Uint8(0)
         ret = sdl2.SDL_GetTextureAlphaMod(texture, byref(talpha))
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         assert talpha.value == alpha
 
 def test_SDL_GetSetTextureBlendMode(texture):
@@ -430,12 +424,10 @@ def test_SDL_GetSetTextureBlendMode(texture):
     )
     for mode in modes:
         ret = sdl2.SDL_SetTextureBlendMode(texture, mode)
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         tmode = blendmode.SDL_BlendMode()
         ret = sdl2.SDL_GetTextureBlendMode(texture, byref(tmode))
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         assert tmode.value == mode
 
 @pytest.mark.skipif(sdl2.dll.version < 2012, reason="not available")
@@ -447,12 +439,10 @@ def test_SDL_GetSetTextureScaleMode(texture):
     )
     for mode in modes:
         ret = sdl2.SDL_SetTextureScaleMode(texture, mode)
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         tmode = sdl2.SDL_ScaleMode()
         ret = sdl2.SDL_GetTextureScaleMode(texture, byref(tmode))
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         assert tmode.value == mode
 
 @pytest.mark.skipif(sdl2.dll.version < 2018, reason="not available")
@@ -461,8 +451,7 @@ def test_SDL_GetSetTextureUserData(texture):
     dat_raw = ctypes.c_char_p(b"hello!")
     dat = ctypes.cast(dat_raw, ctypes.c_void_p)
     ret = sdl2.SDL_SetTextureUserData(texture, dat)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     # Try retrieving the user data
     dat_ptr = sdl2.SDL_GetTextureUserData(texture)
     assert SDL_GetError() == b""
@@ -537,8 +526,7 @@ def test_SDL_GetSetRenderTarget(supported_renderers):
             renderer, pixfmt, sdl2.SDL_TEXTUREACCESS_TARGET, 10, 10
         )
         ret = sdl2.SDL_SetRenderTarget(renderer, tex)
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         tgt = sdl2.SDL_GetRenderTarget(renderer)
         assert SDL_GetError() == b""
         assert isinstance(tgt.contents, sdl2.SDL_Texture)
@@ -558,8 +546,7 @@ def test_SDL_RenderGetSetLogicalSize(sw_renderer):
 
     # Try setting the logical size to 1/10 of normal
     ret = sdl2.SDL_RenderSetLogicalSize(renderer, 10, 10)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     lw, lh = c_int(0), c_int(0)
     sdl2.SDL_RenderGetLogicalSize(renderer, byref(lw), byref(lh))
     assert [lw.value, lh.value] == [10, 10]
@@ -597,16 +584,14 @@ def test_SDL_RenderGetSetViewport(sw_renderer):
     )
     # First, try setting viewport to whole window
     ret = sdl2.SDL_RenderSetViewport(renderer, None)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     vport = rect.SDL_Rect()
     sdl2.SDL_RenderGetViewport(renderer, byref(vport))
     assert vport == rect.SDL_Rect(0, 0, 100, 100)
     # Then, try setting it to different sizes
     for r in rects:
         ret = sdl2.SDL_RenderSetViewport(renderer, r)
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         sdl2.SDL_RenderGetViewport(renderer, byref(vport))
         assert vport == r
 
@@ -636,8 +621,7 @@ def test_SDL_RenderWindowToLogical(with_renderer):
     assert wy.value == 50
     # Set custom scaling on the renderer
     ret = sdl2.SDL_RenderSetScale(renderer, 2.0, 0.5)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     # Test again after resizing
     sdl2.SDL_RenderWindowToLogical(renderer, 50, 50, byref(lx), byref(ly))
     assert lx.value == 25
@@ -669,8 +653,7 @@ def test_SDL_GetSetRenderDrawColor(with_renderer):
     )
     for r, g, b, a in colors:
         ret = sdl2.SDL_SetRenderDrawColor(renderer, r, g, b, a)
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         rr, rg, rb, ra = Uint8(0), Uint8(0), Uint8(0), Uint8(0)
         ret = sdl2.SDL_GetRenderDrawColor(
             renderer, byref(rr), byref(rg), byref(rb), byref(ra)
@@ -688,8 +671,7 @@ def test_SDL_GetSetRenderDrawBlendMode(with_renderer):
     ]
     for mode in modes:
         ret = sdl2.SDL_SetRenderDrawBlendMode(renderer, mode)
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         bmode = blendmode.SDL_BlendMode()
         ret = sdl2.SDL_GetRenderDrawBlendMode(renderer, byref(bmode))
         assert ret == 0
@@ -833,8 +815,7 @@ def test_SDL_RenderGeometry(sw_renderer):
     ret = sdl2.SDL_RenderGeometry(
         renderer, None, vtx, len(vertices), None, 0
     )
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     # TODO: Actually check the surface for the rendered triangle
 
 @pytest.mark.skipif(sdl2.dll.version < 2018, reason="not available")
@@ -859,8 +840,7 @@ def test_SDL_RenderGeometryRaw(sw_renderer):
         uv, xy_size,
         3, None, 0, 1
     )
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     # Check the surface for the rendered triangle
     RED_RGBA = 0xFF0000FF
     BLACK_RGBA = 0x000000FF

--- a/sdl2/test/sdl_test.py
+++ b/sdl2/test/sdl_test.py
@@ -5,6 +5,7 @@ from sdl2 import (
     SDL_INIT_TIMER, SDL_INIT_AUDIO, SDL_INIT_VIDEO, SDL_INIT_JOYSTICK, SDL_INIT_HAPTIC,
     SDL_INIT_GAMECONTROLLER, SDL_INIT_EVENTS, SDL_INIT_SENSOR, SDL_INIT_EVERYTHING
 )
+from .conftest import _check_error_msg
 
 subsystems = {
     'timer': SDL_INIT_TIMER,
@@ -40,11 +41,11 @@ def test_SDL_Init():
 def test_SDL_InitSubSystem():
     sdl2.SDL_ClearError()
     ret = sdl2.SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO)
-    assert ret == 0, sdl2.SDL_GetError().decode('utf-8', 'replace')
+    assert ret == 0, _check_error_msg()
     # Test initializing an additional subsystem
     assert sdl2.SDL_WasInit(0) & SDL_INIT_TIMER != SDL_INIT_TIMER
     ret = sdl2.SDL_InitSubSystem(SDL_INIT_TIMER)
-    assert ret == 0, sdl2.SDL_GetError().decode('utf-8', 'replace')
+    assert ret == 0, _check_error_msg()
     assert sdl2.SDL_WasInit(0) & SDL_INIT_TIMER == SDL_INIT_TIMER
     # Test shutting down a single subsystem
     sdl2.SDL_QuitSubSystem(SDL_INIT_AUDIO)

--- a/sdl2/test/sdlmixer_test.py
+++ b/sdl2/test/sdlmixer_test.py
@@ -6,6 +6,8 @@ from ctypes import byref, c_int, c_uint16
 import sdl2
 from sdl2.stdinc import SDL_TRUE, SDL_FALSE
 from sdl2 import SDL_Init, SDL_Quit, rwops, version, audio
+from .conftest import _check_error_msg
+
 if sys.version_info[0] >= 3:
     from functools import reduce
 
@@ -32,7 +34,7 @@ def with_sdl_mixer():
     # Initialize SDL2 with video and audio subsystems
     sdl2.SDL_ClearError()
     ret = sdl2.SDL_Init(sdl2.SDL_INIT_VIDEO | sdl2.SDL_INIT_AUDIO)
-    assert ret == 0, sdl2.SDL_GetError().decode('utf-8', 'replace')
+    assert ret == 0, _check_error_msg()
     # Initialize SDL_mixer and open an audio device
     flags = (
         sdlmixer.MIX_INIT_FLAC | sdlmixer.MIX_INIT_MOD | sdlmixer.MIX_INIT_MP3 |

--- a/sdl2/test/sensor_test.py
+++ b/sdl2/test/sensor_test.py
@@ -6,6 +6,7 @@ from sdl2 import SDL_Init, SDL_Quit, SDL_INIT_SENSOR, Uint64
 from sdl2.events import SDL_QUERY, SDL_ENABLE, SDL_IGNORE
 from sdl2.stdinc import SDL_TRUE, SDL_FALSE
 from sdl2.error import SDL_GetError, SDL_ClearError
+from .conftest import _check_error_msg
 
 #TODO: Rewrite these tests in the current joystick/gamecontroller format
 
@@ -19,7 +20,7 @@ pytestmark = pytest.mark.skipif(ret != 0 or not available, reason=skipmsg)
 
 def test_SDL_NumSensors():
     ret = SDL_Init(SDL_INIT_SENSOR)
-    assert ret == 0, sdl2.SDL_GetError().decode('utf-8', 'replace')
+    assert ret == 0, _check_error_msg()
     retval = sdl2.SDL_NumSensors()
     SDL_Quit()
     assert retval >= 0

--- a/sdl2/test/shape_test.py
+++ b/sdl2/test/shape_test.py
@@ -4,6 +4,12 @@ import ctypes
 import sdl2
 from sdl2 import SDL_Init, SDL_Quit, SDL_QuitSubSystem, SDL_INIT_EVERYTHING
 from sdl2 import video, surface
+from .conftest import SDL_VIDEODRIVER
+
+# Skip tests if video driver doesn't support shaped windows
+if SDL_VIDEODRIVER in ["dummy", "wayland"]:
+    msg = "not supported by {0} driver".format(SDL_VIDEODRIVER)
+    pytest.skip(msg, allow_module_level=True)
 
 
 class TestSDLShape(object):
@@ -21,8 +27,6 @@ class TestSDLShape(object):
         SDL_Quit()
 
     def test_SDL_CreateShapedWindow(self):
-        if video.SDL_GetCurrentVideoDriver() == b"dummy":
-            pytest.skip("dummy video driver does not support shaped windows")
         flags = (video.SDL_WINDOW_HIDDEN,)
         for flag in flags:
             window = sdl2.SDL_CreateShapedWindow(b"Test", 10, 10, 10, 10,
@@ -31,8 +35,6 @@ class TestSDLShape(object):
             video.SDL_DestroyWindow(window)
 
     def test_SDL_IsShapedWindow(self):
-        if video.SDL_GetCurrentVideoDriver() == b"dummy":
-            pytest.skip("dummy video driver does not support shaped windows")
         flags = (video.SDL_WINDOW_HIDDEN,)
         for flag in flags:
             window = sdl2.SDL_CreateShapedWindow(b"Test", 10, 10, 10, 10,
@@ -49,8 +51,6 @@ class TestSDLShape(object):
             video.SDL_DestroyWindow(window)
 
     def test_SDL_SetWindowShape(self):
-        if video.SDL_GetCurrentVideoDriver() == b"dummy":
-            pytest.skip("dummy video driver does not support shaped windows")
         sf = surface.SDL_CreateRGBSurface(0, 10, 10, 32,
                                           0xFF000000,
                                           0x00FF0000,
@@ -97,8 +97,6 @@ class TestSDLShape(object):
         surface.SDL_FreeSurface(sf)
 
     def test_SDL_GetShapedWindowMode(self):
-        if video.SDL_GetCurrentVideoDriver() == b"dummy":
-            pytest.skip("dummy video driver does not support shaped windows")
         flags = (video.SDL_WINDOW_HIDDEN,)
         for flag in flags:
             window = sdl2.SDL_CreateShapedWindow(b"Test", 10, 10, 10, 10,

--- a/sdl2/test/syswm_test.py
+++ b/sdl2/test/syswm_test.py
@@ -34,9 +34,7 @@ def test_SDL_GetWindowWMInfo(with_sdl):
     version.SDL_VERSION(wminfo.version)
     ret = sdl2.SDL_GetWindowWMInfo(window, ctypes.byref(wminfo))
     video.SDL_DestroyWindow(window)
-    if not ret == SDL_TRUE:
-        assert SDL_GetError() == b""
-        assert ret == SDL_TRUE
+    assert ret == SDL_TRUE, _check_error_msg()
     # Test window manager types for different platforms
     platform = sys.platform
     if platform in ("win32", "cygwin", "msys"):

--- a/sdl2/test/touch_test.py
+++ b/sdl2/test/touch_test.py
@@ -2,6 +2,7 @@ import pytest
 import sdl2
 from sdl2 import SDL_Init, SDL_Quit, SDL_QuitSubSystem
 from sdl2.error import SDL_GetError, SDL_ClearError
+from .conftest import _check_error_msg
 
 
 # Check if we have any touch devices before running tests
@@ -18,7 +19,7 @@ def with_sdl():
     sdl2.SDL_SetHint(sdl2.SDL_HINT_MOUSE_TOUCH_EVENTS, b"1")
     sdl2.SDL_ClearError()
     ret = sdl2.SDL_Init(sdl2.SDL_INIT_VIDEO)
-    assert ret == 0, sdl2.SDL_GetError().decode('utf-8', 'replace')
+    assert ret == 0, _check_error_msg()
     yield
     sdl2.SDL_Quit()
 
@@ -31,8 +32,7 @@ def test_SDL_GetTouchDevice():
     count = sdl2.SDL_GetNumTouchDevices()
     for i in range(count):
         dev_id = sdl2.SDL_GetTouchDevice(i)
-        assert SDL_GetError() == b""
-        assert dev_id != 0
+        assert dev_id != 0, _check_error_msg()
 
 @pytest.mark.skipif(sdl2.dll.version < 2022, reason="not available")
 @pytest.mark.skipif(devices == 0, reason="No available touch devices")
@@ -40,8 +40,7 @@ def test_SDL_GetTouchName(with_sdl):
     count = sdl2.SDL_GetNumTouchDevices()
     for i in range(count):
         name = sdl2.SDL_GetTouchName(i)
-        assert SDL_GetError() == b""
-        assert len(name) > 0
+        assert len(name) > 0, _check_error_msg()
 
 @pytest.mark.skipif(sdl2.dll.version < 2010, reason="not available")
 @pytest.mark.skipif(devices == 0, reason="No available touch devices")
@@ -54,8 +53,7 @@ def test_SDL_GetTouchDeviceType():
     count = sdl2.SDL_GetNumTouchDevices()
     for i in range(count):
         dev_id = sdl2.SDL_GetTouchDevice(i)
-        assert SDL_GetError() == b""
-        assert dev_id != 0
+        assert dev_id != 0, _check_error_msg()
         dev_type = sdl2.SDL_GetTouchDeviceType(dev_id)
         assert dev_type in types
 
@@ -64,19 +62,16 @@ def test_SDL_GetNumTouchFingers():
     count = sdl2.SDL_GetNumTouchDevices()
     for i in range(count):
         dev_id = sdl2.SDL_GetTouchDevice(i)
-        assert SDL_GetError() == b""
-        assert dev_id != 0
+        assert dev_id != 0, _check_error_msg()
         fingers = sdl2.SDL_GetNumTouchFingers(dev_id)
-        assert SDL_GetError() == b""
-        assert fingers >= 0
+        assert fingers >= 0, _check_error_msg()
 
 @pytest.mark.skipif(devices == 0, reason="No available touch devices")
 def test_SDL_GetTouchFinger():
     count = sdl2.SDL_GetNumTouchDevices()
     for i in range(count):
         dev_id = sdl2.SDL_GetTouchDevice(i)
-        assert SDL_GetError() == b""
-        assert dev_id != 0
+        assert dev_id != 0, _check_error_msg()
         fingers = sdl2.SDL_GetNumTouchFingers(dev_id)
         assert fingers >= 0
         for f in range(0, fingers):

--- a/sdl2/test/video_test.py
+++ b/sdl2/test/video_test.py
@@ -918,7 +918,13 @@ def test_SDL_GL_GetSetSwapInterval(gl_window):
     for value in [0, 1]:
         ret = sdl2.SDL_GL_SetSwapInterval(value)
         if ret == 0:
-            assert sdl2.SDL_GL_GetSwapInterval() == value
+            actual = sdl2.SDL_GL_GetSwapInterval()
+            if value == 1 and SDL_VIDEODRIVER == "x11":
+                # XWayland seems to enable adaptive sync (-1) by default when
+                # enabling vsync (1)
+                assert actual in [-1, 1]
+            else:
+                assert actual == value
 
 @pytest.mark.skipif(DRIVER_DUMMY, reason="Doesn't work with dummy driver")
 def test_SDL_GL_SwapWindow(gl_window):

--- a/sdl2/test/video_test.py
+++ b/sdl2/test/video_test.py
@@ -52,9 +52,9 @@ def with_sdl_gl(with_sdl):
 def window(with_sdl):
     flag = sdl2.SDL_WINDOW_BORDERLESS
     w = sdl2.SDL_CreateWindow(b"Test", 10, 40, 12, 13, flag)
-    if not isinstance(w.contents, sdl2.SDL_Window):
+    if not w:
         assert SDL_GetError() == b""
-        assert isinstance(w.contents, sdl2.SDL_Window)
+    assert isinstance(w.contents, sdl2.SDL_Window)
     sdl2.SDL_ClearError()
     yield w
     sdl2.SDL_DestroyWindow(w)
@@ -63,9 +63,9 @@ def window(with_sdl):
 def decorated_window(with_sdl):
     flag = sdl2.SDL_WINDOW_RESIZABLE
     w = sdl2.SDL_CreateWindow(b"Test", 10, 40, 12, 13, flag)
-    if not isinstance(w.contents, sdl2.SDL_Window):
+    if not w:
         assert SDL_GetError() == b""
-        assert isinstance(w.contents, sdl2.SDL_Window)
+    assert isinstance(w.contents, sdl2.SDL_Window)
     sdl2.SDL_ClearError()
     yield w
     sdl2.SDL_DestroyWindow(w)
@@ -74,9 +74,9 @@ def decorated_window(with_sdl):
 def gl_window(with_sdl_gl):
     flag = sdl2.SDL_WINDOW_OPENGL
     w = sdl2.SDL_CreateWindow(b"OpenGL", 10, 40, 12, 13, flag)
-    if not isinstance(w.contents, sdl2.SDL_Window):
+    if not w:
         assert SDL_GetError() == b""
-        assert isinstance(w.contents, sdl2.SDL_Window)
+    assert isinstance(w.contents, sdl2.SDL_Window)
     sdl2.SDL_ClearError()
     ctx = sdl2.SDL_GL_CreateContext(w)
     assert SDL_GetError() == b""
@@ -86,9 +86,9 @@ def gl_window(with_sdl_gl):
 
 def _create_window(name, h, w, x, y, flags):
     window = sdl2.SDL_CreateWindow(name, h, w, x, y, flags)
-    if not isinstance(window.contents, sdl2.SDL_Window):
+    if not window:
         assert SDL_GetError() == b""
-        assert isinstance(window.contents, sdl2.SDL_Window)
+    assert isinstance(window.contents, sdl2.SDL_Window)
     sdl2.SDL_ClearError()
     return window
 
@@ -862,43 +862,43 @@ def test_SDL_GL_ExtensionSupported(gl_window):
 
 @pytest.mark.skipif(DRIVER_DUMMY, reason="Doesn't work with dummy driver")
 def test_SDL_GL_GetSetResetAttribute(with_sdl_gl):
-    # Create a context and get its bit depth
+    # Create a context and get its major version
     window = _create_window(
         b"OpenGL", 10, 40, 12, 13, sdl2.SDL_WINDOW_OPENGL
     )
     ctx = sdl2.SDL_GL_CreateContext(window)
     bufstate = c_int(0)
-    ret = sdl2.SDL_GL_GetAttribute(sdl2.SDL_GL_DOUBLEBUFFER, byref(bufstate))
+    ret = sdl2.SDL_GL_GetAttribute(sdl2.SDL_GL_CONTEXT_MAJOR_VERSION, byref(bufstate))
     sdl2.SDL_GL_DeleteContext(ctx)
     sdl2.SDL_DestroyWindow(window)
     assert ret == 0, _check_error_msg()
     sdl2.SDL_ClearError()
-    # Try setting a different GL bit depth
-    new_bufstate = 0 if bufstate.value == 1 else 1
-    sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_DOUBLEBUFFER, new_bufstate)
+    # Try setting a different GL context version
+    new_bufstate = 1 if bufstate.value == 2 else 2
+    sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_MAJOR_VERSION, new_bufstate)
     assert ret == 0, _check_error_msg()
     sdl2.SDL_ClearError()
-    # Create a new context to see if it's using the new bit depth 
+    # Create a new context to see if it's using the new version
     window = _create_window(
         b"OpenGL", 10, 40, 12, 13, sdl2.SDL_WINDOW_OPENGL
     )
     ctx = sdl2.SDL_GL_CreateContext(window)
     val = c_int(0)
-    ret = sdl2.SDL_GL_GetAttribute(sdl2.SDL_GL_DOUBLEBUFFER, byref(val))
+    ret = sdl2.SDL_GL_GetAttribute(sdl2.SDL_GL_CONTEXT_MAJOR_VERSION, byref(val))
     sdl2.SDL_GL_DeleteContext(ctx)
     sdl2.SDL_DestroyWindow(window)
     assert ret == 0, _check_error_msg()
     sdl2.SDL_ClearError()
     assert bufstate.value != val.value
     assert val.value == new_bufstate
-    # Try resetting the context and see if it goes back to the original depth
+    # Try resetting the context and see if it goes back to the original version
     sdl2.SDL_GL_ResetAttributes()
     window = _create_window(
         b"OpenGL", 10, 40, 12, 13, sdl2.SDL_WINDOW_OPENGL
     )
     ctx = sdl2.SDL_GL_CreateContext(window)
     val = c_int(0)
-    ret = sdl2.SDL_GL_GetAttribute(sdl2.SDL_GL_DOUBLEBUFFER, byref(val))
+    ret = sdl2.SDL_GL_GetAttribute(sdl2.SDL_GL_CONTEXT_MAJOR_VERSION, byref(val))
     sdl2.SDL_GL_DeleteContext(ctx)
     sdl2.SDL_DestroyWindow(window)
     assert bufstate.value == val.value

--- a/sdl2/test/video_test.py
+++ b/sdl2/test/video_test.py
@@ -7,7 +7,7 @@ import pytest
 import sdl2
 from sdl2.stdinc import SDL_FALSE, SDL_TRUE, Uint16
 from sdl2 import rect, pixels, surface, SDL_GetError
-from .conftest import SKIP_ANNOYING, SDL_VIDEODRIVER
+from .conftest import SKIP_ANNOYING, SDL_VIDEODRIVER, _check_error_msg
 
 # Some tests don't work properly with some video drivers, so check the name
 DRIVER_DUMMY = False
@@ -44,8 +44,7 @@ def get_opengl_path():
 @pytest.fixture
 def with_sdl_gl(with_sdl):
     ret = sdl2.SDL_GL_LoadLibrary(None)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     yield
     sdl2.SDL_GL_UnloadLibrary()
 
@@ -310,8 +309,7 @@ def test_SDL_GetDisplayDPI(with_sdl):
         ret = sdl2.SDL_GetDisplayDPI(
             index, byref(ddpi), byref(hdpi), byref(vdpi)
         )
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         assert ddpi.value >= 96.0
         assert hdpi.value >= 96.0
         assert vdpi.value >= 96.0
@@ -385,9 +383,7 @@ def test_SDL_GetWindowDisplayMode(window):
     # NOTE: Gets fullscreen mode of parent display, not size of window
     dmode = sdl2.SDL_DisplayMode()
     ret = sdl2.SDL_GetWindowDisplayMode(window, byref(dmode))
-    if ret != 0:
-        assert SDL_GetError() == b""
-        assert ret == 0
+    assert ret == 0, _check_error_msg()
     assert dmode.w > 0
     assert dmode.h > 0
 
@@ -401,9 +397,7 @@ def test_SDL_SetWindowDisplayMode(window):
     sdl2.SDL_SetWindowDisplayMode(window, dmode)
     wmode = sdl2.SDL_DisplayMode()
     ret = sdl2.SDL_GetWindowDisplayMode(window, byref(wmode))
-    if ret != 0:
-        assert SDL_GetError() == b""
-        assert ret == 0
+    assert ret == 0, _check_error_msg()
     assert dmode == wmode
 
 @pytest.mark.skipif(sdl2.dll.version < 2018, reason="not available")
@@ -667,8 +661,7 @@ def test_SDL_UpdateWindowSurface(window):
     sf = sdl2.SDL_GetWindowSurface(window)
     assert isinstance(sf.contents, surface.SDL_Surface)
     ret = sdl2.SDL_UpdateWindowSurface(window)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
 
 def test_SDL_UpdateWindowSurfaceRects(window):
     sf = sdl2.SDL_GetWindowSurface(window)
@@ -681,8 +674,7 @@ def test_SDL_UpdateWindowSurfaceRects(window):
     )
     rect_ptr = cast(rectlist, POINTER(rect.SDL_Rect))
     ret = sdl2.SDL_UpdateWindowSurfaceRects(window, rect_ptr, 4)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
 
 @pytest.mark.skip("Can't set window grab for some reason")
 def test_SDL_GetSetWindowGrab(decorated_window):
@@ -728,15 +720,13 @@ def test_SDL_GetSetWindowMouseRect(with_sdl):
     window = _create_window(b"Test", 200, 200, 200, 200, flags)
     # Try setting a mouse boundary
     ret = sdl2.SDL_SetWindowMouseRect(window, byref(bounds_in))
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     bounds_out = sdl2.SDL_GetWindowMouseRect(window)
     assert bounds_out != None
     assert bounds_in == bounds_out.contents
     # Try removing the boundary
     ret = sdl2.SDL_SetWindowMouseRect(window, None)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     bounds_out = sdl2.SDL_GetWindowMouseRect(window)
     assert not bounds_out  # bounds_out should be null pointer
     sdl2.SDL_DestroyWindow(window)
@@ -765,11 +755,9 @@ def test_SDL_GetSetWindowOpacity(window):
     assert opacity.value == 1.0
     if not SDL_VIDEODRIVER in ["dummy", "wayland"]:
         ret = sdl2.SDL_SetWindowOpacity(window, 0.5)
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         ret = sdl2.SDL_GetWindowOpacity(window, byref(opacity))
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         assert opacity.value == 0.5
 
 @pytest.mark.skipif(sdl2.dll.version < 2005, reason="not available")
@@ -777,16 +765,14 @@ def test_SDL_SetWindowModalFor(window, decorated_window):
     # NOTE: Only supported on X11
     ret = sdl2.SDL_SetWindowModalFor(window, decorated_window)
     if sdl2.SDL_GetCurrentVideoDriver() == b"x11":
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
 
 @pytest.mark.skipif(sdl2.dll.version < 2005, reason="not available")
 def test_SDL_SetWindowInputFocus(window):
     # NOTE: Only supported on X11
     ret = sdl2.SDL_SetWindowInputFocus(window)
     if SDL_VIDEODRIVER == "x11":
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
 
 def test_SDL_GetSetWindowGammaRamp(window):
     if SDL_VIDEODRIVER in ["dummy", "wayland"]:
@@ -794,14 +780,12 @@ def test_SDL_GetSetWindowGammaRamp(window):
     vals = (Uint16 * 256)()
     pixels.SDL_CalculateGammaRamp(0.5, vals)
     ret = sdl2.SDL_SetWindowGammaRamp(window, vals, vals, vals)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     r = (Uint16 * 256)()
     g = (Uint16 * 256)()
     b = (Uint16 * 256)()
     ret = sdl2.SDL_GetWindowGammaRamp(window, r, g, b)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     for i in range(len(vals)):
         assert r[i] == vals[i]
         assert g[i] == vals[i]
@@ -819,8 +803,7 @@ def test_SDL_FlashWindow(window):
     # NOTE: Not the most comprehensive test, but it does test the basic bindings
     ret = sdl2.SDL_FlashWindow(window, sdl2.SDL_FLASH_BRIEFLY)
     if not DRIVER_DUMMY:
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
 
 def test_screensaver(with_sdl):
     sdl2.SDL_EnableScreenSaver()
@@ -844,15 +827,13 @@ def test_SDL_GL_LoadUnloadLibrary(with_sdl):
     # TODO: Test whether other GL functions work after GL is unloaded
     # (unloading doesn't always work right on macOS for some reason)
     ret = sdl2.SDL_GL_LoadLibrary(None)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     sdl2.SDL_GL_UnloadLibrary()
     # Try loading a library from a path
     if has_opengl_lib():
         fpath = get_opengl_path().encode("utf-8")
         ret = sdl2.SDL_GL_LoadLibrary(fpath)
-        assert SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         sdl2.SDL_GL_UnloadLibrary()
 
 @pytest.mark.skipif(DRIVER_DUMMY, reason="Doesn't work with dummy driver")
@@ -890,16 +871,12 @@ def test_SDL_GL_GetSetResetAttribute(with_sdl_gl):
     ret = sdl2.SDL_GL_GetAttribute(sdl2.SDL_GL_DOUBLEBUFFER, byref(bufstate))
     sdl2.SDL_GL_DeleteContext(ctx)
     sdl2.SDL_DestroyWindow(window)
-    if ret != 0:
-        assert SDL_GetError() == b""
-        assert ret == 0
+    assert ret == 0, _check_error_msg()
     sdl2.SDL_ClearError()
     # Try setting a different GL bit depth
     new_bufstate = 0 if bufstate.value == 1 else 1
     sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_DOUBLEBUFFER, new_bufstate)
-    if ret != 0:
-        assert SDL_GetError() == b""
-        assert ret == 0
+    assert ret == 0, _check_error_msg()
     sdl2.SDL_ClearError()
     # Create a new context to see if it's using the new bit depth 
     window = _create_window(
@@ -910,9 +887,7 @@ def test_SDL_GL_GetSetResetAttribute(with_sdl_gl):
     ret = sdl2.SDL_GL_GetAttribute(sdl2.SDL_GL_DOUBLEBUFFER, byref(val))
     sdl2.SDL_GL_DeleteContext(ctx)
     sdl2.SDL_DestroyWindow(window)
-    if ret != 0:
-        assert SDL_GetError() == b""
-        assert ret == 0
+    assert ret == 0, _check_error_msg()
     sdl2.SDL_ClearError()
     assert bufstate.value != val.value
     assert val.value == new_bufstate
@@ -932,15 +907,13 @@ def test_SDL_GL_GetSetResetAttribute(with_sdl_gl):
 def test_SDL_GL_MakeCurrent(gl_window):
     window, ctx = gl_window
     ret = sdl2.SDL_GL_MakeCurrent(window, ctx)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
 
 @pytest.mark.skipif(DRIVER_DUMMY, reason="Doesn't work with dummy driver")
 def test_SDL_GL_GetSetSwapInterval(gl_window):
     window, ctx = gl_window
     ret = sdl2.SDL_GL_MakeCurrent(window, ctx)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     # Try enabling/disabling OpenGL vsync
     for value in [0, 1]:
         ret = sdl2.SDL_GL_SetSwapInterval(value)
@@ -951,8 +924,7 @@ def test_SDL_GL_GetSetSwapInterval(gl_window):
 def test_SDL_GL_SwapWindow(gl_window):
     window, ctx = gl_window
     ret = sdl2.SDL_GL_MakeCurrent(window, ctx)
-    assert SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     sdl2.SDL_GL_SwapWindow(window)
     sdl2.SDL_GL_SwapWindow(window)
     sdl2.SDL_GL_SwapWindow(window)


### PR DESCRIPTION
<!--Thanks for contributing to PySDL2!-->

# PR Description

Closes #257. This PR fixes a bunch of unsafe assumptions about SDL errors in the existing test suite, and also fixes/skips a number of tests that don't currently work right with Wayland or XWayland.

This also tries re-adding Python 2.7 runners to the CI, since official support got removed from `setup-python` this week.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
