### PR TITLE
tests: SDL_GetError() != b'' isn't an error

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -45,6 +45,7 @@ Thanks to everyone else for their assistance, support, fixes and improvements:
 * Radomir Dopieralski
 * Rob Rolls
 * Robert Winkler
+* Robie Basak
 * Roger Flores
 * Simon McVittie
 * smea lum

--- a/sdl2/test/gamecontroller_test.py
+++ b/sdl2/test/gamecontroller_test.py
@@ -51,7 +51,7 @@ def gamepads(with_sdl):
     for i in range(count):
         if sdl2.SDL_IsGameController(i) == SDL_TRUE:
             pad = sdl2.SDL_GameControllerOpen(i)
-            assert sdl2.SDL_GetError() == b""
+            assert pad, _check_error_msg()
             assert isinstance(pad.contents, sdl2.SDL_GameController)
             devices.append(pad)
     yield devices
@@ -133,21 +133,18 @@ def test_SDL_GameControllerMappingForGUID(with_sdl):
 def test_SDL_GameControllerMapping(gamepads):
     for pad in gamepads:
         mapping = sdl2.SDL_GameControllerMapping(pad)
-        assert SDL_GetError() == b""
         assert mapping == None or type(mapping) in (str, bytes)
 
 def test_SDL_IsGameController(with_sdl):
     count = joystick.SDL_NumJoysticks()
     for index in range(count):
         ret = sdl2.SDL_IsGameController(index)
-        assert sdl2.SDL_GetError() == b""
         assert ret in [SDL_TRUE, SDL_FALSE]
 
 def test_SDL_GameControllerNameForIndex(with_sdl):
     count = joystick.SDL_NumJoysticks()
     for index in range(count):
         name = sdl2.SDL_GameControllerNameForIndex(index)
-        assert sdl2.SDL_GetError() == b""
         assert name == None or type(name) in (str, bytes)
 
 @pytest.mark.skipif(sdl2.dll.version < 2231, reason="not available")
@@ -174,7 +171,7 @@ def test_SDL_GameControllerOpenClose(with_sdl):
     for index in range(count):
         if sdl2.SDL_IsGameController(index) == SDL_TRUE:
             pad = sdl2.SDL_GameControllerOpen(index)
-            assert sdl2.SDL_GetError() == b""
+            assert pad, _check_error_msg()
             assert isinstance(pad.contents, sdl2.SDL_GameController)
             sdl2.SDL_GameControllerClose(pad)
 
@@ -220,7 +217,6 @@ def test_SDL_GameControllerPath(gamepads):
 def test_SDL_GameControllerGetType(gamepads):
     for pad in gamepads:
         padtype = sdl2.SDL_GameControllerGetType(pad)
-        assert SDL_GetError() == b""
         assert padtype in gamepad_types
         if is_virtual(pad):
             assert padtype == sdl2.SDL_CONTROLLER_TYPE_VIRTUAL
@@ -244,7 +240,6 @@ def test_SDL_GameControllerSetPlayerIndex(gamepads):
 def test_SDL_GameControllerGetVendor(gamepads):
     for pad in gamepads:
         vid = sdl2.SDL_GameControllerGetVendor(pad)
-        assert SDL_GetError() == b""
         if not is_virtual(pad):
             assert vid > 0
 
@@ -252,7 +247,6 @@ def test_SDL_GameControllerGetVendor(gamepads):
 def test_SDL_GameControllerGetProduct(gamepads):
     for pad in gamepads:
         pid = sdl2.SDL_GameControllerGetProduct(pad)
-        assert SDL_GetError() == b""
         if not is_virtual(pad):
             assert pid > 0
 
@@ -260,21 +254,18 @@ def test_SDL_GameControllerGetProduct(gamepads):
 def test_SDL_GameControllerGetProductVersion(gamepads):
     for pad in gamepads:
         pver = sdl2.SDL_GameControllerGetProductVersion(pad)
-        assert SDL_GetError() == b""
         assert pver >= 0
 
 @pytest.mark.skipif(sdl2.dll.version < 2231, reason="not available")
 def test_SDL_GameControllerGetFirmwareVersion(gamepads):
     for pad in gamepads:
         fw_ver = sdl2.SDL_GameControllerGetFirmwareVersion(pad)
-        assert SDL_GetError() == b""
         assert fw_ver >= 0
 
 @pytest.mark.skipif(sdl2.dll.version < 2014, reason="not available")
 def test_SDL_GameControllerGetSerial(gamepads):
     for pad in gamepads:
         serial = sdl2.SDL_GameControllerGetSerial(pad)
-        assert SDL_GetError() == b""
         assert serial == None or type(serial) in (str, bytes)
 
 def test_SDL_GameControllerGetAttached(gamepads):
@@ -285,7 +276,7 @@ def test_SDL_GameControllerGetAttached(gamepads):
 def test_SDL_GameControllerGetJoystick(gamepads):
     for pad in gamepads:
         stick = sdl2.SDL_GameControllerGetJoystick(pad)
-        assert SDL_GetError() == b""
+        assert stick, _check_error_msg()
         assert isinstance(stick.contents, joystick.SDL_Joystick)
 
 def test_SDL_GameControllerEventState(with_sdl):
@@ -298,7 +289,6 @@ def test_SDL_GameControllerEventState(with_sdl):
 def test_SDL_GameControllerUpdate(with_sdl):
     # NOTE: Returns void, can't really test anything else
     sdl2.SDL_GameControllerUpdate()
-    assert SDL_GetError() == b""
 
 def test_SDL_GameControllerGetAxisFromString(with_sdl):
     expected = {


### PR DESCRIPTION
In Ubuntu, we're seeing test failures of the following pattern when moving from libsdl2 2.28.1+dfsg-1 to 2.28.2+dfsg-1:

    > assert sdl2.SDL_GetError() == b""
    E AssertionError: assert b'Unexpected ...r element crc' == b''
    E   Full diff:
    E   - b''
    E   + b'Unexpected controller element crc'

This looks like an issue similar to that fixed in commit 8c39f40. We should check the relevant return value, and only if it indicates failure should we attach any particular meaning to the return value of SDL_GetError().

<!--Thanks for contributing to PySDL2!-->

# PR Description

I'm not sure if this is entirely correct and would appreciate review and feedback! In particular it's not clear to me if this 'Unexpected controller element crc' should result in a test failure and needs fixing elsewhere, and/or if it was caused by a change other than a version bump of libsdl2. However, it seems to me that it would be correct to fix these tests anyway?

You can view the downstream test failure logs at https://autopkgtest.ubuntu.com/results/autopkgtest-mantic/mantic/amd64/p/pysdl2/20230808_001651_edcc4@/log.gz

I found that if I just patch that one out, another test fails. So I looked for all instances of this issue in `sdl2/test/gamecontroller_test.py`, patched them all, and then the test suite passed.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
