### PR TITLE
test: Don't assert that SDL_hid_enumerate doesn't set error

### DIFF
--- a/sdl2/test/hidapi_test.py
+++ b/sdl2/test/hidapi_test.py
@@ -38,10 +38,11 @@ def test_SDL_hid_device_change_count(hidapi_setup):
 
 def test_SDL_hid_enumerate(hidapi_setup):
     devices = sdl2.SDL_hid_enumerate(0, 0)
-    assert SDL_GetError() == b""
+    # Cannot check the error indicator here: a non-error empty list is
+    # indistinguishable from an error, and it is not guaranteed that the
+    # error indicator will not be set as a side-effect of a successful load
     if devices != None:
         sdl2.SDL_hid_free_enumeration(devices)
-        assert SDL_GetError() == b""
 
 
 @pytest.mark.skip("not implemented")


### PR DESCRIPTION
# PR Description

On my Linux system, enumeration succeeds, but the error indicator gets set as a side-effect (which appears to be because the loader checks whether the symbol exists in SDL or a direct dependency before it dlopens libudev).

The API of SDL_hid_enumerate does not make it possible to distinguish between successfully returning an empty list of devices (returns NULL with the error indicator in an undefined state) and a failure (returns NULL with the error indicator set), and systems that run automated tests usually don't have any HID game controllers connected, so we can't make any meaningful use of the error indicator here.

Helps: https://github.com/py-sdl/py-sdl2/issues/257

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [x] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
