### PR TITLE
Remove more misuse of SDL_GetError in tests

### DIFF
--- a/sdl2/test/clipboard_test.py
+++ b/sdl2/test/clipboard_test.py
@@ -8,9 +8,8 @@ from .conftest import SKIP_ANNOYING, _check_error_msg
 def window(with_sdl):
     flag = sdl2.SDL_WINDOW_BORDERLESS
     w = sdl2.SDL_CreateWindow(b"Test", 10, 40, 12, 13, flag)
-    if not isinstance(w.contents, sdl2.SDL_Window):
-        assert sdl2.SDL_GetError() == b""
-        assert isinstance(w.contents, sdl2.SDL_Window)
+    assert w, _check_error_msg()
+    assert isinstance(w.contents, sdl2.SDL_Window)
     sdl2.SDL_ClearError()
     yield w
     sdl2.SDL_DestroyWindow(w)

--- a/sdl2/test/joystick_test.py
+++ b/sdl2/test/joystick_test.py
@@ -427,6 +427,7 @@ def test_SDL_JoystickNumButtons(joysticks):
 def test_SDL_JoystickUpdate(with_sdl):
     # TODO: This is not 100% safe, but in SDL2, JoystickUpdate returns void
     # so we can't reliably detect error
+    sdl2.SDL_ClearError()
     sdl2.SDL_JoystickUpdate()
     assert SDL_GetError() == b""
 

--- a/sdl2/test/joystick_test.py
+++ b/sdl2/test/joystick_test.py
@@ -57,7 +57,7 @@ def joysticks(with_sdl):
     count = sdl2.SDL_NumJoysticks()
     for i in range(count):
         stick = sdl2.SDL_JoystickOpen(i)
-        assert sdl2.SDL_GetError() == b""
+        assert stick, _check_error_msg()
         assert isinstance(stick.contents, sdl2.SDL_Joystick)
         devices.append(stick)
     yield devices
@@ -121,31 +121,30 @@ def test_SDL_JoystickGetDeviceGUID(with_sdl):
 def test_SDL_JoystickGetDeviceVendor(with_sdl):
     count = sdl2.SDL_NumJoysticks()
     for index in range(count):
+        sdl2.SDL_ClearError()
         vid = sdl2.SDL_JoystickGetDeviceVendor(index)
-        assert SDL_GetError() == b""
         if not is_virtual(index):
-            assert vid > 0
+            assert vid > 0, _check_error_msg()
 
 def test_SDL_JoystickGetDeviceProduct(with_sdl):
     count = sdl2.SDL_NumJoysticks()
     for index in range(count):
+        sdl2.SDL_ClearError()
         pid = sdl2.SDL_JoystickGetDeviceProduct(index)
-        assert SDL_GetError() == b""
         if not is_virtual(index):
-            assert pid > 0
+            assert pid > 0, _check_error_msg()
 
 def test_SDL_JoystickGetDeviceProductVersion(with_sdl):
     count = sdl2.SDL_NumJoysticks()
     for index in range(count):
+        sdl2.SDL_ClearError()
         pver = sdl2.SDL_JoystickGetDeviceProductVersion(index)
-        assert SDL_GetError() == b""
-        assert pver >= 0
+        assert pver >= 0, _check_error_msg()
 
 def test_SDL_JoystickGetDeviceType(with_sdl):
     count = sdl2.SDL_NumJoysticks()
     for index in range(count):
         jtype = sdl2.SDL_JoystickGetDeviceType(index)
-        assert SDL_GetError() == b""
         assert jtype in joystick_types
         if is_virtual(index):
             assert jtype == sdl2.SDL_JOYSTICK_TYPE_GAMECONTROLLER
@@ -153,15 +152,17 @@ def test_SDL_JoystickGetDeviceType(with_sdl):
 @pytest.mark.skipif(sdl2.dll.version < 2006, reason="not available")
 def test_SDL_JoystickGetDeviceInstanceID(joysticks):
     for index in range(len(joysticks)):
+        sdl2.SDL_ClearError()
         iid = sdl2.SDL_JoystickGetDeviceInstanceID(index)
-        assert SDL_GetError() == b""
         stick = joysticks[index]
-        assert iid == sdl2.SDL_JoystickInstanceID(stick)
+        assert iid == sdl2.SDL_JoystickInstanceID(stick), _check_error_msg()
 
 def test_SDL_JoystickOpenClose(with_sdl):
     count = sdl2.SDL_NumJoysticks()
     for index in range(count):
+        sdl2.SDL_ClearError()
         stick = sdl2.SDL_JoystickOpen(index)
+        assert stick, _check_error_msg()
         assert isinstance(stick.contents, sdl2.SDL_Joystick)
         sdl2.SDL_JoystickClose(stick)
 
@@ -316,42 +317,40 @@ def test_SDL_JoystickGetGUID(joysticks):
 
 def test_SDL_JoystickGetVendor(joysticks):
     for stick in joysticks:
+        sdl2.SDL_ClearError()
         vid = sdl2.SDL_JoystickGetVendor(stick)
-        assert SDL_GetError() == b""
         if not is_virtual(stick):
-            assert vid > 0
+            assert vid > 0, _check_error_msg()
 
 def test_SDL_JoystickGetProduct(joysticks):
     for stick in joysticks:
+        sdl2.SDL_ClearError()
         pid = sdl2.SDL_JoystickGetProduct(stick)
-        assert SDL_GetError() == b""
         if not is_virtual(stick):
-            assert pid > 0
+            assert pid > 0, _check_error_msg()
 
 def test_SDL_JoystickGetProductVersion(joysticks):
     for stick in joysticks:
+        sdl2.SDL_ClearError()
         pver = sdl2.SDL_JoystickGetProductVersion(stick)
-        assert SDL_GetError() == b""
-        assert pver >= 0
+        assert pver >= 0, _check_error_msg()
 
 @pytest.mark.skipif(sdl2.dll.version < 2231, reason="not available")
 def test_SDL_JoystickGetFirmwareVersion(joysticks):
     for stick in joysticks:
+        sdl2.SDL_ClearError()
         fw_ver = sdl2.SDL_JoystickGetFirmwareVersion(stick)
-        assert SDL_GetError() == b""
-        assert fw_ver >= 0
+        assert fw_ver >= 0, _check_error_msg()
 
 @pytest.mark.skipif(sdl2.dll.version < 2014, reason="not available")
 def test_SDL_JoystickGetSerial(joysticks):
     for stick in joysticks:
         serial = sdl2.SDL_JoystickGetSerial(stick)
-        assert SDL_GetError() == b""
         assert serial == None or type(serial) in (str, bytes)
 
 def test_SDL_JoystickGetType(joysticks):
     for stick in joysticks:
         jtype = sdl2.SDL_JoystickGetType(stick)
-        assert SDL_GetError() == b""
         assert jtype in joystick_types
         if is_virtual(stick):
             assert jtype == sdl2.SDL_JOYSTICK_TYPE_GAMECONTROLLER
@@ -426,7 +425,8 @@ def test_SDL_JoystickNumButtons(joysticks):
             assert buttons == 4
 
 def test_SDL_JoystickUpdate(with_sdl):
-    # NOTE: Returns void, can't really test anything else
+    # TODO: This is not 100% safe, but in SDL2, JoystickUpdate returns void
+    # so we can't reliably detect error
     sdl2.SDL_JoystickUpdate()
     assert SDL_GetError() == b""
 
@@ -450,7 +450,6 @@ def test_SDL_JoystickGetAxisInitialState(joysticks):
             ret = sdl2.SDL_JoystickGetAxisInitialState(
                 stick, axis, byref(init_state)
             )
-            assert SDL_GetError() == b""
             assert -32768 <= init_state.value <= 32767
             assert ret in [SDL_TRUE, SDL_FALSE]
 
@@ -544,5 +543,4 @@ def test_SDL_JoystickCurrentPowerLevel(joysticks):
     ]
     for stick in joysticks:
         pwr = sdl2.SDL_JoystickCurrentPowerLevel(stick)
-        assert SDL_GetError() == b""
         assert pwr in levels

--- a/sdl2/test/keyboard_test.py
+++ b/sdl2/test/keyboard_test.py
@@ -170,6 +170,7 @@ def test_SDL_SetTextInputRect(with_sdl):
     coords = [(0, 0, 0, 0), (-10, -70, 3, 6), (10, 10, 10, 10)]
     for x, y, w, h in coords:
         r = rect.SDL_Rect(x, y, w, h)
+        sdl2.SDL_ClearError()
         sdl2.SDL_SetTextInputRect(r)
         assert SDL_GetError() == b""
     sdl2.SDL_StopTextInput()

--- a/sdl2/test/pixels_test.py
+++ b/sdl2/test/pixels_test.py
@@ -6,6 +6,7 @@ import sdl2
 from sdl2 import SDL_Init, SDL_Quit, SDL_INIT_EVERYTHING, SDL_TRUE
 from sdl2 import SDL_Color
 from sdl2.stdinc import Uint8, Uint16, Uint32
+from .conftest import _check_error_msg
 
 RGBA8888 = [0xFF000000, 0x00FF0000, 0x0000FF00, 0x000000FF]
 RGBX8888 = [0xFF000000, 0x00FF0000, 0x0000FF00, 0]
@@ -163,11 +164,11 @@ def test_SDL_PixelFormatEnumToMasks():
     bpp = c_int(0)
     r, g, b, a = Uint32(0), Uint32(0), Uint32(0), Uint32(0)
     for fmt, expected in formats:
+        sdl2.SDL_ClearError()
         ret = sdl2.SDL_PixelFormatEnumToMasks(
             fmt, byref(bpp), byref(r), byref(g), byref(b), byref(a)
         )
-        assert sdl2.SDL_GetError() == b""
-        assert ret == SDL_TRUE
+        assert ret == SDL_TRUE, _check_error_msg()
         assert [x.value for x in (bpp, r, g, b, a)] == expected
 
 def test_SDL_AllocFreeFormat():
@@ -232,8 +233,7 @@ def test_SDL_SetPixelFormatPalette():
     pixfmt = sdl2.SDL_AllocFormat(sdl2.SDL_PIXELFORMAT_INDEX1MSB)
     assert isinstance(pixfmt.contents, sdl2.SDL_PixelFormat)
     ret = sdl2.SDL_SetPixelFormatPalette(pixfmt, palette)
-    assert sdl2.SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
 
     fmt_palette = pixfmt.contents.palette.contents
     assert fmt_palette.colors[1].r == 128

--- a/sdl2/test/sdl2ext_draw_test.py
+++ b/sdl2/test/sdl2ext_draw_test.py
@@ -17,7 +17,6 @@ except:
 @pytest.fixture
 def testsurf(with_sdl):
     sf = _create_surface((10, 10), fmt="RGBA32")
-    assert SDL_GetError() == b""
     yield sf
     SDL_FreeSurface(sf)
 

--- a/sdl2/test/sdl2ext_font_test.py
+++ b/sdl2/test/sdl2ext_font_test.py
@@ -6,6 +6,7 @@ from sdl2.ext.compat import byteify
 from sdl2.ext.pixelaccess import pixels2d
 from sdl2.ext.surface import _create_surface
 from sdl2 import surface, pixels, rwops, SDL_ClearError, SDL_GetError
+from .conftest import _check_error_msg
 
 _HASSDLTTF = True
 try:
@@ -39,8 +40,7 @@ def with_font_ttf(with_sdl):
         SDL_ClearError()
         fontpath = RESOURCES.get_path("tuffy.ttf")
         font = sdl2ext.FontTTF(fontpath, 20, RED_RGBA)
-        assert SDL_GetError() == b""
-        assert font
+        assert font, _check_error_msg()
         yield font
         font.close()
         gc.collect()
@@ -253,26 +253,22 @@ class TestFontTTF(object):
         # Try opening and closing a font
         fontpath = RESOURCES.get_path("tuffy.ttf")
         font = sdl2ext.FontTTF(fontpath, 20, RED_RGBA)
-        assert SDL_GetError() == b""
-        assert font
+        assert font, _check_error_msg()
         font.close()
 
         # Try opening a font with size specified in pt
         font = sdl2ext.FontTTF(fontpath, "20pt", RED_RGBA)
-        assert SDL_GetError() == b""
-        assert font
+        assert font, _check_error_msg()
         font.close()
 
         # Try opening a font with size specified in pixels
         font = sdl2ext.FontTTF(fontpath, "20px", RED_RGBA)
-        assert SDL_GetError() == b""
-        assert font
+        assert font, _check_error_msg()
         
         # Try opening a font with a custom set of height chars
         chars = "aeiou"
         font2 = sdl2ext.FontTTF(fontpath, "20px", RED_RGBA, height_chars=chars)
-        assert SDL_GetError() == b""
-        assert font
+        assert font, _check_error_msg()
         assert font._parse_size("20px") != font2._parse_size("20px")
         font.close()
         font2.close()
@@ -295,8 +291,7 @@ class TestFontTTF(object):
         font_file = open(fontpath, "rb")
         font_rw = rwops.rw_from_object(font_file)
         font = sdl2ext.FontTTF(font_rw, 20, RED_RGBA)
-        assert SDL_GetError() == b""
-        assert font
+        assert font, _check_error_msg()
         font.close()
 
     def test_get_ttf_font(self, with_font_ttf):
@@ -334,21 +329,21 @@ class TestFontTTF(object):
         # Try rendering some text
         msg = "hello there!"
         text = font.render_text(msg)
-        assert SDL_GetError() == b""
+        assert text, _check_error_msg()
         assert isinstance(text, surface.SDL_Surface)
         assert text.format.contents.format == pixels.SDL_PIXELFORMAT_ARGB8888
 
         # Test multiline rendering
         msg = "hello\nthere!"
         text2 = font.render_text(msg)
-        assert SDL_GetError() == b""
+        assert text2, _check_error_msg()
         assert isinstance(text2, surface.SDL_Surface)
         assert text2.h > text.h
 
         # Test strings with empty lines
         msg = "hello\n\nthere!\n"
         text3 = font.render_text(msg)
-        assert SDL_GetError() == b""
+        assert text3, _check_error_msg()
         assert isinstance(text3, surface.SDL_Surface)
         assert text3.h > text2.h
         surface.SDL_FreeSurface(text3)
@@ -356,7 +351,7 @@ class TestFontTTF(object):
         # Test custom line height
         msg = "hello\nthere!"
         text3 = font.render_text(msg, line_h=100)
-        assert SDL_GetError() == b""
+        assert text3, _check_error_msg()
         assert isinstance(text3, surface.SDL_Surface)
         assert text3.h > text2.h
         surface.SDL_FreeSurface(text3)
@@ -364,7 +359,7 @@ class TestFontTTF(object):
         # Test custom line height as a string (in px)
         msg = "hello\nthere!"
         text3 = font.render_text(msg, line_h='100px')
-        assert SDL_GetError() == b""
+        assert text3, _check_error_msg()
         assert isinstance(text3, surface.SDL_Surface)
         assert text3.h > text2.h
         surface.SDL_FreeSurface(text3)
@@ -372,7 +367,7 @@ class TestFontTTF(object):
         # Test custom line height as a percentage
         msg = "hello\nthere!"
         text3 = font.render_text(msg, line_h='110%')
-        assert SDL_GetError() == b""
+        assert text3, _check_error_msg()
         assert isinstance(text3, surface.SDL_Surface)
         assert text3.h > text2.h
         surface.SDL_FreeSurface(text3)
@@ -380,7 +375,7 @@ class TestFontTTF(object):
         # Test wrap width
         msg = "hello there! This is a very long line of text."
         text3 = font.render_text(msg, width=200)
-        assert SDL_GetError() == b""
+        assert text3, _check_error_msg()
         assert isinstance(text3, surface.SDL_Surface)
         assert text3.h > text.h
         surface.SDL_FreeSurface(text3)
@@ -389,7 +384,7 @@ class TestFontTTF(object):
         msg = "hello there!"
         font.add_style("blue", 30, (0, 0, 255, 255))
         text3 = font.render_text(msg, "blue")
-        assert SDL_GetError() == b""
+        assert text3, _check_error_msg()
         assert isinstance(text3, surface.SDL_Surface)
         surface.SDL_FreeSurface(text3)
 
@@ -397,16 +392,17 @@ class TestFontTTF(object):
         msg = "hello there!"
         font.add_style("red_on_white", 30, RED_RGBA, (255, 255, 255))
         text3 = font.render_text(msg, "red_on_white")
-        assert SDL_GetError() == b""
+        assert text3, _check_error_msg()
         assert isinstance(text3, surface.SDL_Surface)
         surface.SDL_FreeSurface(text3)
 
         # Test font alignment (not extensive)
         msg = "hello there!\nThis is a very long line of\ntext."
         for align in ["left", "center", "right"]:
+            SDL_ClearError()
             tmp = font.render_text(msg, align=align)
-            assert SDL_GetError() == b""
-            assert isinstance(text3, surface.SDL_Surface)
+            assert tmp, _check_error_msg()
+            assert isinstance(tmp, surface.SDL_Surface)
             surface.SDL_FreeSurface(tmp)
 
         surface.SDL_FreeSurface(text)

--- a/sdl2/test/sdl2ext_spritesystem_test.py
+++ b/sdl2/test/sdl2ext_spritesystem_test.py
@@ -10,6 +10,7 @@ from sdl2.render import (
 from sdl2.surface import SDL_Surface, SDL_CreateRGBSurface, SDL_FreeSurface
 from sdl2.pixels import SDL_MapRGBA
 from sdl2.error import SDL_GetError, SDL_ClearError
+from .conftest import _check_error_msg
 
 try:
     import PIL
@@ -81,12 +82,14 @@ class TestSpriteFactory(object):
 
         for w, h in sprite_test_sizes:
             for bpp in (1, 4, 8, 12, 15, 16, 24, 32):
+                SDL_ClearError()
                 sprite = sfactory.create_sprite(size=(w, h), bpp=bpp)
+                assert sprite, _check_error_msg()
                 assert isinstance(sprite, sdl2ext.SoftwareSprite)
-                assert SDL_GetError() == b""
+            SDL_ClearError()
             sprite = tfactory.create_sprite(size=(w, h))
+            assert sprite, _check_error_msg()
             assert isinstance(sprite, sdl2ext.TextureSprite)
-            assert SDL_GetError() == b""
 
         with pytest.raises(sdl2ext.SDLError):
             tfactory.create_sprite(size=(0, 1))
@@ -95,9 +98,10 @@ class TestSpriteFactory(object):
         factory = sdl2ext.SpriteFactory(sdl2ext.SOFTWARE)
         for w, h in sprite_test_sizes:
             for bpp in (1, 4, 8, 12, 15, 16, 24, 32):
+                SDL_ClearError()
                 sprite = factory.create_software_sprite((w, h), bpp)
+                assert sprite, _check_error_msg()
                 assert isinstance(sprite, sdl2ext.SoftwareSprite)
-                assert SDL_GetError() == b""
 
         with pytest.raises(TypeError):
             factory.create_software_sprite(size=None)
@@ -119,9 +123,10 @@ class TestSpriteFactory(object):
         renderer = sdl2ext.Renderer(window)
         factory = sdl2ext.SpriteFactory(sdl2ext.TEXTURE, renderer=renderer)
         for w, h in sprite_test_sizes:
+            SDL_ClearError()
             sprite = factory.create_texture_sprite(renderer, size=(w, h))
+            assert sprite, _check_error_msg()
             assert isinstance(sprite, sdl2ext.TextureSprite)
-            assert SDL_GetError() == b""
             del sprite
 
         # Test different access flags
@@ -130,11 +135,12 @@ class TestSpriteFactory(object):
             SDL_TEXTUREACCESS_STREAMING,
             SDL_TEXTUREACCESS_TARGET
         ):
+            SDL_ClearError()
             sprite = factory.create_texture_sprite(
                 renderer, size=(64, 64), access=flag
             )
+            assert sprite, _check_error_msg()
             assert isinstance(sprite, sdl2ext.TextureSprite)
-            assert SDL_GetError() == b""
             del sprite
 
     def test_from_image(self, with_sdl):

--- a/sdl2/test/sdl_test.py
+++ b/sdl2/test/sdl_test.py
@@ -25,15 +25,17 @@ def test_SDL_Init():
     for name, flags in subsystems.items():
         ret = sdl2.SDL_Init(flags)
         err = sdl2.SDL_GetError()
-        if name in ['timer', 'audio', 'video', 'events']:
-            assert ret == 0, err.decode('utf-8', 'replace')
-        if err:
-            err = err.decode('utf-8')
-            print("Error loading {0} subsystem: {1}".format(name, err))
-            sdl2.SDL_ClearError()
+        if ret == 0 and sdl2.SDL_WasInit(0) & flags == flags:
+            supported.append(name)
         else:
-            if ret == 0 and sdl2.SDL_WasInit(0) & flags == flags:
-                supported.append(name)
+            # If essential subsystem doesn't load, fail test
+            if name in ['timer', 'audio', 'video', 'events']:
+                assert False, err.decode('utf-8', 'replace')
+            # If optional subsystem doesn't load, print warning
+            else:
+                err = err.decode('utf-8')
+                print("Error loading {0} subsystem: {1}".format(name, err))
+                sdl2.SDL_ClearError()
         sdl2.SDL_Quit()
     print("Supported SDL2 subsystems:")
     print(supported)

--- a/sdl2/test/sdlgfx_test.py
+++ b/sdl2/test/sdlgfx_test.py
@@ -5,6 +5,7 @@ import pytest
 import sdl2
 from sdl2 import SDL_Init, SDL_Quit, SDL_INIT_VIDEO
 from sdl2 import surface, render
+from .conftest import _check_error_msg
 
 sdlgfx = pytest.importorskip("sdl2.sdlgfx")
 
@@ -31,9 +32,9 @@ def software_renderer(with_sdl):
     sdl2.SDL_ClearError()
     # Create a new SDL surface and make it the target of a new renderer
     target = surface.SDL_CreateRGBSurface(0, height, width, 32, 0, 0, 0, 0)
-    assert sdl2.SDL_GetError() == b""
+    assert target, _check_error_msg()
     renderer = render.SDL_CreateSoftwareRenderer(target)
-    assert sdl2.SDL_GetError() == b""
+    assert renderer, _check_error_msg()
     # Return the renderer and surface for the test
     yield (renderer, target)
     # Free memory for the renderer and surface once we're done

--- a/sdl2/test/sdlimage_test.py
+++ b/sdl2/test/sdlimage_test.py
@@ -6,6 +6,7 @@ import pytest
 
 import sdl2
 from sdl2 import SDL_Init, SDL_Quit, version, surface, rwops, render
+from .conftest import _check_error_msg
 
 sdlimage = pytest.importorskip("sdl2.sdlimage")
 
@@ -626,8 +627,7 @@ def test_IMG_SavePNG(tmpdir):
     # Try saving the PNG to a new folder
     outpath = os.path.join(str(tmpdir), "save_test.png")
     ret = sdlimage.IMG_SavePNG(sf, outpath.encode("utf-8"))
-    assert sdl2.SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     assert os.path.exists(outpath)
     surface.SDL_FreeSurface(sf)
 
@@ -642,8 +642,7 @@ def test_IMG_SavePNG_RW(tmpdir):
     rw = rwops.SDL_RWFromFile(outpath.encode("utf-8"), b"wb")
     ret = sdlimage.IMG_SavePNG_RW(sf, rw, 0)
     sdl2.SDL_RWclose(rw)
-    assert sdl2.SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     assert os.path.exists(outpath)
 
     # Try reopening the RW as a PNG
@@ -662,8 +661,7 @@ def test_IMG_SaveJPG(tmpdir):
     # Try saving as JPG to a new folder
     outpath = os.path.join(str(tmpdir), "save_test.jpg")
     ret = sdlimage.IMG_SaveJPG(sf, outpath.encode("utf-8"), 90)
-    assert sdl2.SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     assert os.path.exists(outpath)
     surface.SDL_FreeSurface(sf)
 
@@ -679,8 +677,7 @@ def test_IMG_SaveJPG_RW(tmpdir):
     rw = rwops.SDL_RWFromFile(outpath.encode("utf-8"), b"wb")
     ret = sdlimage.IMG_SaveJPG_RW(sf, rw, 0, 90)
     sdl2.SDL_RWclose(rw)
-    assert sdl2.SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     assert os.path.exists(outpath)
 
     # Try reopening the RW as a JPG

--- a/sdl2/test/surface_test.py
+++ b/sdl2/test/surface_test.py
@@ -8,6 +8,7 @@ from sdl2.ext import CTypesView
 from sdl2 import SDL_Init, SDL_Quit, SDL_INIT_EVERYTHING
 from sdl2.stdinc import Uint8, Uint16, Uint32, SDL_TRUE, SDL_FALSE
 from sdl2 import blendmode, endian, pixels, rect, rwops, error
+from .conftest import _check_error_msg
 
 
 @pytest.fixture
@@ -15,7 +16,7 @@ def test_surf_argb(with_sdl):
     w, h = 32, 32
     fmt = pixels.SDL_PIXELFORMAT_ARGB8888
     sf = sdl2.SDL_CreateRGBSurfaceWithFormat(0, w, h, 0, fmt)
-    assert sdl2.SDL_GetError() == b""
+    assert sf, _check_error_msg()
     assert isinstance(sf.contents, sdl2.SDL_Surface)
     yield sf
     sdl2.SDL_FreeSurface(sf)
@@ -92,7 +93,7 @@ def test_SDL_CreateFreeRGBSurface(with_sdl):
         for bpp in alldepths:
             sdl2.SDL_ClearError()
             sf = sdl2.SDL_CreateRGBSurface(0, w, h, bpp, 0, 0, 0, 0)
-            assert sdl2.SDL_GetError() == b""
+            assert sf, _check_error_msg()
             assert isinstance(sf.contents, sdl2.SDL_Surface)
             sdl2.SDL_FreeSurface(sf)
 
@@ -105,12 +106,11 @@ def test_SDL_CreateFreeRGBSurface(with_sdl):
         ret = pixels.SDL_PixelFormatEnumToMasks(
             fmt, byref(bpp), byref(rmask), byref(gmask), byref(bmask), byref(amask)
         )
-        assert sdl2.SDL_GetError() == b""
-        assert ret == SDL_TRUE
+        assert ret == SDL_TRUE, _check_error_msg()
         sf = sdl2.SDL_CreateRGBSurface(
             0, 16, 16, bpp, rmask, gmask, bmask, amask
         )
-        assert sdl2.SDL_GetError() == b""
+        assert sf, _check_error_msg()
         assert isinstance(sf.contents, sdl2.SDL_Surface)
         sdl2.SDL_FreeSurface(sf)
 
@@ -122,7 +122,7 @@ def test_SDL_CreateRGBSurfaceWithFormat(with_sdl):
                 continue
             sdl2.SDL_ClearError()
             sf = sdl2.SDL_CreateRGBSurfaceWithFormat(0, w, h, 0, fmt)
-            assert sdl2.SDL_GetError() == b""
+            assert sf, _check_error_msg()
             assert isinstance(sf.contents, sdl2.SDL_Surface)
             sdl2.SDL_FreeSurface(sf)
 
@@ -135,7 +135,7 @@ def test_SDL_CreateRGBSurfaceFrom(with_sdl):
             buf['ptr'], buf['w'], buf['h'], buf['bpp'], buf['pitch'],
             rmask, gmask, bmask, amask
         )
-        assert sdl2.SDL_GetError() == b""
+        assert sf, _check_error_msg()
         assert isinstance(sf.contents, sdl2.SDL_Surface)
         sdl2.SDL_FreeSurface(sf)
 
@@ -146,7 +146,7 @@ def test_SDL_CreateRGBSurfaceWithFormatFrom(with_sdl):
         sf = sdl2.SDL_CreateRGBSurfaceWithFormatFrom(
             buf['ptr'], buf['w'], buf['h'], buf['bpp'], buf['pitch'], buf['fmt']
         )
-        assert sdl2.SDL_GetError() == b""
+        assert sf, _check_error_msg()
         assert isinstance(sf.contents, sdl2.SDL_Surface)
         sdl2.SDL_FreeSurface(sf)
 
@@ -162,8 +162,7 @@ def test_SDL_ConvertPixels(with_sdl):
             buf['w'], buf['h'], buf['fmt'], buf['ptr'], buf['pitch'],
             buf['fmt'], dst_ptr, buf['pitch'],
         )
-        assert sdl2.SDL_GetError() == b""
-        assert ret == 0
+        assert ret == 0, _check_error_msg()
         for index, val in enumerate(dst):
             assert val == buf['pixels'][index]
     
@@ -177,8 +176,7 @@ def test_SDL_ConvertPixels(with_sdl):
         buf['w'], buf['h'], buf['fmt'], buf['ptr'], buf['pitch'],
         pixels.SDL_PIXELFORMAT_ABGR8888, dst_ptr, buf['pitch'],
     )
-    assert sdl2.SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     for index, val in enumerate(dst):
         assert sdl2.SDL_Swap32(val) == buf['pixels'][index]
 
@@ -200,14 +198,14 @@ def test_SDL_LoadBMP_RW(with_sdl):
     with open(bmp_testfile, "rb") as f:
         imgrw = rwops.rw_from_object(f)
         imgsurface = sdl2.SDL_LoadBMP_RW(imgrw, 0)
-        assert sdl2.SDL_GetError() == b""
+        assert imgsurface, _check_error_msg()
         assert isinstance(imgsurface.contents, sdl2.SDL_Surface)
         sdl2.SDL_FreeSurface(imgsurface)
 
 
 def test_SDL_LoadBMP(with_sdl):
     imgsurface = sdl2.SDL_LoadBMP(bmp_testfile.encode("utf-8"))
-    assert sdl2.SDL_GetError() == b""
+    assert imgsurface, _check_error_msg()
     assert isinstance(imgsurface.contents, sdl2.SDL_Surface)
     sdl2.SDL_FreeSurface(imgsurface)
 
@@ -227,13 +225,11 @@ def test_SDL_SetSurfaceRLEMUSTLOCK(test_surf_argb):
     sf = test_surf_argb
     # Test that surface requires locking after RLE set
     ret = sdl2.SDL_SetSurfaceRLE(sf, 1)
-    assert sdl2.SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     #assert sdl2.SDL_MUSTLOCK(sf)
     # Try disabling RLE
     ret = sdl2.SDL_SetSurfaceRLE(sf, 0)
-    assert sdl2.SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     #assert not sdl2.SDL_MUSTLOCK(sf)
 
 
@@ -243,13 +239,11 @@ def test_SDL_HasSurfaceRLE(test_surf_argb):
     # Test for success before and after setting RLE
     assert sdl2.SDL_HasSurfaceRLE(sf) == SDL_FALSE
     ret = sdl2.SDL_SetSurfaceRLE(sf, 1)
-    assert sdl2.SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     assert sdl2.SDL_HasSurfaceRLE(sf) == SDL_TRUE
     # Disable RLE on surface again
     ret = sdl2.SDL_SetSurfaceRLE(sf, 0)
-    assert sdl2.SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     assert sdl2.SDL_HasSurfaceRLE(sf) == SDL_FALSE
 
 
@@ -268,17 +262,15 @@ def test_SDL_GetSetColorKey(with_sdl):
             continue
         sdl2.SDL_ClearError()
         sf = sdl2.SDL_CreateRGBSurfaceWithFormat(0, 10, 10, 0, fmt)
-        assert sdl2.SDL_GetError() == b""
+        assert sf, _check_error_msg()
         assert isinstance(sf.contents, sdl2.SDL_Surface)
         pixfmt = sdl2.SDL_AllocFormat(fmt)
         for r, g, b in colorkeys:
             key = pixels.SDL_MapRGB(pixfmt, r, g, b)
             ret = sdl2.SDL_SetColorKey(sf, 1, key)
-            assert sdl2.SDL_GetError() == b""
-            assert ret == 0
+            assert ret == 0, _check_error_msg()
             ret = sdl2.SDL_GetColorKey(sf, byref(currentkey))
-            assert sdl2.SDL_GetError() == b""
-            assert ret == 0
+            assert ret == 0, _check_error_msg()
         pixels.SDL_FreeFormat(pixfmt)
         sdl2.SDL_FreeSurface(sf)
 
@@ -289,8 +281,7 @@ def test_SDL_HasColorKey(test_surf_argb):
     assert sdl2.SDL_HasColorKey(sf) == SDL_FALSE
     key = pixels.SDL_MapRGB(sf.contents.format, 255, 255, 255)
     ret = sdl2.SDL_SetColorKey(sf, 1, key)
-    assert sdl2.SDL_GetError() == b""
-    assert ret == 0
+    assert ret == 0, _check_error_msg()
     assert sdl2.SDL_HasColorKey(sf) == SDL_TRUE
 
 
@@ -335,7 +326,7 @@ class TestSDLSurface(object):
                                                   bmask, amask)
                 assert isinstance(sf.contents, sdl2.SDL_Surface)
                 csf = sdl2.SDL_ConvertSurface(sf, pfmt, 0)
-                assert csf, error.SDL_GetError()
+                assert csf, _check_error_msg()
                 assert isinstance(csf.contents, sdl2.SDL_Surface)
                 sdl2.SDL_FreeSurface(sf)
                 sdl2.SDL_FreeSurface(csf)
@@ -385,7 +376,7 @@ class TestSDLSurface(object):
                                                   bmask, amask)
                 assert isinstance(sf.contents, sdl2.SDL_Surface)
                 csf = sdl2.SDL_ConvertSurfaceFormat(sf, pfmt, 0)
-                assert csf, error.SDL_GetError()
+                assert csf, _check_error_msg()
                 assert isinstance(csf.contents, sdl2.SDL_Surface)
                 sdl2.SDL_FreeSurface(sf)
                 sdl2.SDL_FreeSurface(csf)

--- a/sdl2/test/syswm_test.py
+++ b/sdl2/test/syswm_test.py
@@ -5,6 +5,7 @@ import ctypes
 import sdl2
 from sdl2.stdinc import SDL_TRUE
 from sdl2 import video, version, SDL_GetError
+from .conftest import _check_error_msg
 
 # Check if using dummy video driver
 DRIVER_DUMMY = os.getenv("SDL_VIDEODRIVER", "") == "dummy"
@@ -26,9 +27,8 @@ def test_SDL_GetWindowWMInfo(with_sdl):
     window = video.SDL_CreateWindow(
         b"Test", 10, 10, 10, 10, video.SDL_WINDOW_HIDDEN
     )
-    if not isinstance(window.contents, video.SDL_Window):
-        assert SDL_GetError() == b""
-        assert isinstance(window.contents, video.SDL_Window)
+    assert window, _check_error_msg()
+    assert isinstance(window.contents, video.SDL_Window)
     sdl2.SDL_ClearError()
     wminfo = sdl2.SDL_SysWMinfo()
     version.SDL_VERSION(wminfo.version)

--- a/sdl2/test/video_test.py
+++ b/sdl2/test/video_test.py
@@ -337,8 +337,7 @@ def test_SDL_CreateDestroyWindow(with_sdl):
     flag = sdl2.SDL_WINDOW_BORDERLESS
     window = sdl2.SDL_CreateWindow(b"Test", 10, 40, 12, 13, flag)
     assert window, _check_error_msg()
-    if not isinstance(window.contents, sdl2.SDL_Window):
-        assert isinstance(window.contents, sdl2.SDL_Window)
+    assert isinstance(window.contents, sdl2.SDL_Window)
     sdl2.SDL_DestroyWindow(window)
 
 @pytest.mark.skip("not implemented")


### PR DESCRIPTION
<!--Thanks for contributing to PySDL2!-->

# PR Description

Closes #257 (for real this time, I think). This fixes a bunch of assorted unit tests to only check for `SDL_GetError` output when a function's return value indicates a failure, since `SDL_SetError` is often used internally by SDL2 to set non-fatal warning messages (leading to tests breaking unexpectedly with new SDL releases).

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [ ] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
