### PR TITLE
Remove test setting hint with empty string

### DIFF
--- a/sdl2/test/hints_test.py
+++ b/sdl2/test/hints_test.py
@@ -32,8 +32,6 @@ def test_SDL_SetHint(with_sdl):
     assert sdl2.SDL_GetHint(b"TEST") == b"32"
     assert sdl2.SDL_SetHint(b"TEST", b"abcdef") == 1
     assert sdl2.SDL_GetHint(b"TEST") == b"abcdef"
-    assert sdl2.SDL_SetHint(b"", b"hi") == 1
-    assert sdl2.SDL_GetHint(b"") == b"hi"
 
 def test_SDL_SetHintWithPriority(with_sdl):
     tst_hints = [


### PR DESCRIPTION
Setting a SDL hint with an empty name does not make sense.

This is also what upstream thinks:
https://github.com/libsdl-org/SDL/pull/12538#issuecomment-2725851422

# PR Description

Remove test case testing setting a hint with no name.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
