### PR TITLE
Fix test_get_events failure with sdl2-compat

### DIFF
--- a/sdl2/test/sdl2ext_test.py
+++ b/sdl2/test/sdl2ext_test.py
@@ -3,7 +3,7 @@ import pytest
 import sdl2
 from sdl2 import ext as sdl2ext
 from sdl2 import (
-    SDL_Quit, SDL_WasInit, SDL_FlushEvent, SDL_UserEvent, SDL_PushEvent, 
+    SDL_Quit, SDL_WasInit, SDL_FlushEvents, SDL_UserEvent, SDL_PushEvent,
     SDL_Event, SDL_USEREVENT, SDL_FIRSTEVENT, SDL_LASTEVENT, SDL_QUIT,
 )
 
@@ -58,7 +58,7 @@ def test_init_quit():
     sdl2ext.quit()
 
 def test_get_events(with_sdl_ext):
-    SDL_FlushEvent(SDL_FIRSTEVENT, SDL_LASTEVENT)
+    SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT)
     for x in range(12):
         event = SDL_Event()
         event.type = SDL_USEREVENT + x


### PR DESCRIPTION
# PR Description

The test meant to call `SDL_FlushEvents()` to flush all events, but instead only flushed `SDL_FIRSTEVENT`. This mistake was harmless until SDL3, which does have queued events at this point that must be flushed for the test expectations to be met.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
