### PR TITLE
Set window gamma ramp and set window brightness can fail

### DIFF
--- a/sdl2/test/video_test.py
+++ b/sdl2/test/video_test.py
@@ -793,16 +793,16 @@ def test_SDL_GetSetWindowGammaRamp(window):
     vals = (Uint16 * 256)()
     pixels.SDL_CalculateGammaRamp(0.5, vals)
     ret = sdl2.SDL_SetWindowGammaRamp(window, vals, vals, vals)
-    assert ret == 0, _check_error_msg()
-    r = (Uint16 * 256)()
-    g = (Uint16 * 256)()
-    b = (Uint16 * 256)()
-    ret = sdl2.SDL_GetWindowGammaRamp(window, r, g, b)
-    assert ret == 0, _check_error_msg()
-    for i in range(len(vals)):
-        assert r[i] == vals[i]
-        assert g[i] == vals[i]
-        assert b[i] == vals[i]
+    if ret == 0:
+        r = (Uint16 * 256)()
+        g = (Uint16 * 256)()
+        b = (Uint16 * 256)()
+        ret = sdl2.SDL_GetWindowGammaRamp(window, r, g, b)
+        assert ret == 0, _check_error_msg()
+        for i in range(len(vals)):
+            assert r[i] == vals[i]
+            assert g[i] == vals[i]
+            assert b[i] == vals[i]
 
 @pytest.mark.skip("not implemented")
 @pytest.mark.skipif(sdl2.dll.version < 2004, reason="not available")

--- a/sdl2/test/video_test.py
+++ b/sdl2/test/video_test.py
@@ -760,7 +760,6 @@ def test_SDL_GetSetWindowBrightness(window):
             val = sdl2.SDL_GetWindowBrightness(window)
             assert round(abs(val-b), 7) == 0
             count += 1
-    assert count > 0
 
 def test_SDL_GetSetWindowOpacity(window):
     opacity = c_float(0)


### PR DESCRIPTION
`SDL_SetWindowBrightness` and `SDL_SetWindowGammaRamp` are not available anymore in SDL3,
so fail when used in sdl2-compat.

# PR Description

 <!--Please describe your pull request here.-->

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [x] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
