### PR TITLE
surface_test: Expect intended behaviour if SDL2 is new enough

### DIFF
--- a/sdl2/test/surface_test.py
+++ b/sdl2/test/surface_test.py
@@ -467,13 +467,20 @@ class TestSDLSurface(object):
             sdl2.SDL_FreeSurface(sf)
 
     def test_SDL_GetSetClipRect(self):
+        # A bug in intersecting empty rectangles was fixed in SDL2 2.33.x
+        # and in sdl2-compat (which reports its version as >= 2.32.50)
+        if sdl2.dll.version_tuple >= (2, 32, 50):
+            true_if_fixed = True
+        else:
+            true_if_fixed = None
+
         rectlist = ((rect.SDL_Rect(0, 0, 0, 0), SDL_FALSE, True),
-                    (rect.SDL_Rect(2, 2, 0, 0), SDL_FALSE, False),
+                    (rect.SDL_Rect(2, 2, 0, 0), SDL_FALSE, true_if_fixed),
                     (rect.SDL_Rect(2, 2, 5, 1), SDL_TRUE, True),
                     (rect.SDL_Rect(6, 5, 10, 3), SDL_TRUE, False),
                     (rect.SDL_Rect(0, 0, 10, 10), SDL_TRUE, True),
-                    (rect.SDL_Rect(0, 0, -10, 10), SDL_FALSE, False),
-                    (rect.SDL_Rect(0, 0, -10, -10), SDL_FALSE, False),
+                    (rect.SDL_Rect(0, 0, -10, 10), SDL_FALSE, true_if_fixed),
+                    (rect.SDL_Rect(0, 0, -10, -10), SDL_FALSE, true_if_fixed),
                     (rect.SDL_Rect(-10, -10, 10, 10), SDL_FALSE, False),
                     (rect.SDL_Rect(10, -10, 10, 10), SDL_FALSE, False),
                     (rect.SDL_Rect(10, 10, 10, 10), SDL_TRUE, False)
@@ -490,7 +497,8 @@ class TestSDLSurface(object):
             sdl2.SDL_GetClipRect(sf, byref(clip))
             err = "Could not set clip rect %s" % r
             assert retval == clipsetval, "retval: " + err
-            assert (clip == r) == cmpval, "clip: " + err
+            if cmpval is not None:
+                assert (clip == r) == cmpval, "clip: " + err
         sdl2.SDL_FreeSurface(sf)
 
     def test_SDL_GetSetSurfaceAlphaMod(self):


### PR DESCRIPTION
In older versions of "classic" SDL2, including the 2.32.x series, intersecting an empty rectangle with another rectangle would have an empty result (w=0, h=0) with an uninitialized position (x, y arbitrary). However, SDL upstream considers this to be a bug, and it caused observable visual issues in some older games when used in conjunction with sdl12-compat.

This test previously asserted that the clip rectangle would not be equal to the requested clip rectangle, but that was only true because of this bug: the uninitialized x and y coordinates were very unlikely to be equal to the requested rectangle. With the bug fix in sdl2-compat, the coordinates come out as equal to those that were requested.

If SDL2 is sufficiently new, assert that the comparison result is true (which is the correct result according to SDL upstream), and if not, make no assertion (in case the bug fix is backported).

Resolves: https://github.com/py-sdl/py-sdl2/issues/289

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
