### PR TITLE
video_test: Skip SDL_SetWindowMouseRect with sdl2-compat dummy driver

### DIFF
--- a/sdl2/test/video_test.py
+++ b/sdl2/test/video_test.py
@@ -730,6 +730,7 @@ def test_SDL_GetGrabbedWindow(window):
     # NOTE: Should implement this once the above tests are fixed
     pass
 
+@pytest.mark.skipif(DRIVER_DUMMY, reason="Not implemented by dummy driver")
 @pytest.mark.skipif(sdl2.dll.version < 2018, reason="not available")
 def test_SDL_GetSetWindowMouseRect(with_sdl):
     flags = sdl2.SDL_WINDOW_BORDERLESS


### PR DESCRIPTION
This driver doesn't implement mouse confinement.

# Merge Checklist

<!--To merge your PR we need to first take the following points into account.-->
<!--Please just leave this checklist untouched-->

- [x] the PR has been reviewed and all comments are resolved
- [ ] all [CI][what-is-ci] checks pass
- [ ] (if applicable): the PR description includes the phrase `closes #<issue-number>` to [automatically close an issue][auto-close-documentation]
- [ ] (if applicable): bug fixes, new features, or [API][what-is-api] changes are documented in [news.rst][news-file]


[what-is-ci]: https://help.github.com/en/actions/building-and-testing-code-with-continuous-integration/about-continuous-integration
[auto-close-documentation]: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
[what-is-api]: https://en.wikipedia.org/wiki/Application_programming_interface
[news-file]: https://github.com/py-sdl/py-sdl2/blob/master/doc/news.rst
